### PR TITLE
Add loki-distributed chart, extract Gateway

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: mla-gateway
+description: Helm chart for KKP MLA Gateway
+type: application
+appVersion: 2.1.0
+version: 0.0.1

--- a/charts/gateway/templates/gateway.yaml
+++ b/charts/gateway/templates/gateway.yaml
@@ -1,0 +1,179 @@
+# Source: loki-distributed/templates/gateway/configmap-gateway.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mla-gateway
+data:
+  nginx.conf: |
+    worker_processes  5;  ## Default: 1
+    error_log  /dev/stderr;
+    pid        /tmp/nginx.pid;
+    worker_rlimit_nofile 8192;
+
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+        '"$request" $body_bytes_sent "$http_referer" '
+        '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log   /dev/stderr  main;
+      sendfile     on;
+      tcp_nopush   on;
+      resolver kube-dns.kube-system.svc.cluster.local;
+
+      server {
+        listen             8080;
+        proxy_set_header   X-Scope-OrgID 1;
+
+        location = / {
+          return 200 'OK';
+          auth_basic off;
+        }
+
+        location = /api/prom/push {
+          proxy_pass       http://loki-distributed-distributor.{{ .Values.mla.namespace }}.svc.cluster.local:3100$request_uri;
+        }
+
+        location = /api/prom/tail {
+          proxy_pass       http://loki-distributed-querier.{{ .Values.mla.namespace }}.svc.cluster.local:3100$request_uri;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+        }
+
+        location ~ /api/prom/.* {
+          proxy_pass       http://loki-distributed-query-frontend.{{ .Values.mla.namespace }}.svc.cluster.local:3100$request_uri;
+        }
+
+        location = /loki/api/v1/push {
+          proxy_pass       http://loki-distributed-distributor.{{ .Values.mla.namespace }}.svc.cluster.local:3100$request_uri;
+        }
+
+        location = /loki/api/v1/tail {
+          proxy_pass       http://loki-distributed-querier.{{ .Values.mla.namespace }}.svc.cluster.local:3100$request_uri;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+        }
+
+        location ~ /loki/api/.* {
+          proxy_pass       http://loki-distributed-query-frontend.{{ .Values.mla.namespace }}.svc.cluster.local:3100$request_uri;
+        }
+      }
+    }
+
+---
+# Source: loki-distributed/templates/gateway/service-gateway.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mla-gateway
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: loki-distributed
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/component: gateway
+
+---
+# Source: loki-distributed/templates/gateway/deployment-gateway.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mla-gateway
+  labels:
+    app.kubernetes.io/name: loki-distributed
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/component: gateway
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki-distributed
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: loki-distributed
+        app.kubernetes.io/instance: loki
+        app.kubernetes.io/component: gateway
+    spec:
+      securityContext:
+        fsGroup: 101
+        runAsGroup: 101
+        runAsNonRoot: true
+        runAsUser: 101
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.19-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx
+            - name: tmp
+              mountPath: /tmp
+            - name: docker-entrypoint-d-override
+              mountPath: /docker-entrypoint.d
+          resources:
+            {}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: loki-distributed
+                  app.kubernetes.io/instance: loki
+                  app.kubernetes.io/component: gateway
+              topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: loki-distributed
+                    app.kubernetes.io/instance: loki
+                    app.kubernetes.io/component: gateway
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+      volumes:
+        - name: config
+          configMap:
+            name: mla-gateway
+        - name: tmp
+          emptyDir: {}
+        - name: docker-entrypoint-d-override
+          emptyDir: {}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -1,0 +1,3 @@
+mla:
+  namespace: mla
+

--- a/charts/loki-distributed/.helmignore
+++ b/charts/loki-distributed/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+doc.yaml
+README.tpl

--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: loki-distributed
+description: Helm chart for Grafana Loki in microservices mode
+type: application
+appVersion: 2.1.0
+version: 0.25.0
+home: https://grafana.github.io/helm-charts
+sources:
+  - https://github.com/grafana/loki
+  - https://grafana.com/oss/loki/
+  - https://grafana.com/docs/loki/latest/
+icon: https://grafana.com/docs/loki/latest/logo_and_name.png
+maintainers:
+  - name: unguiculus

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,0 +1,614 @@
+# loki-distributed
+
+![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+
+Helm chart for Grafana Loki in microservices mode
+
+## Source Code
+
+* <https://github.com/grafana/loki>
+* <https://grafana.com/oss/loki/>
+* <https://grafana.com/docs/loki/latest/>
+
+## Chart Repo
+
+Add the following repo to use the chart:
+
+```console
+helm repo add grafana https://grafana.github.io/helm-charts
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| compactor.enabled | bool | `false` | Specifies whether compactor should be enabled |
+| compactor.extraArgs | list | `[]` | Additional CLI args for the compactor |
+| compactor.extraEnv | list | `[]` | Environment variables to add to the compactor pods |
+| compactor.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the compactor pods |
+| compactor.extraVolumeMounts | list | `[]` | Volume mounts to add to the compactor pods |
+| compactor.extraVolumes | list | `[]` | Volumes to add to the compactor pods |
+| compactor.image.registry | string | `nil` | The Docker registry for the compactor image. Overrides `loki.image.registry` |
+| compactor.image.repository | string | `nil` | Docker image repository for the compactor image. Overrides `loki.image.repository` |
+| compactor.image.tag | string | `nil` | Docker image tag for the compactor image. Overrides `loki.image.tag` |
+| compactor.nodeSelector | object | `{}` | Node selector for compactor pods |
+| compactor.persistence.enabled | bool | `false` | Enable creating PVCs for the compactor |
+| compactor.persistence.size | string | `"10Gi"` | Size of persistent disk |
+| compactor.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| compactor.podAnnotations | object | `{}` | Annotations for compactor pods |
+| compactor.priorityClassName | string | `nil` | The name of the PriorityClass for compactor pods |
+| compactor.resources | object | `{}` | Resource requests and limits for the compactor |
+| compactor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the compactor to shutdown before it is killed |
+| compactor.tolerations | list | `[]` | Tolerations for compactor pods |
+| distributor.affinity | string | Hard node and soft zone anti-affinity | Affinity for distributor pods. Passed through `tpl` and, thus, to be configured as string |
+| distributor.extraArgs | list | `[]` | Additional CLI args for the distributor |
+| distributor.extraEnv | list | `[]` | Environment variables to add to the distributor pods |
+| distributor.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the distributor pods |
+| distributor.extraVolumeMounts | list | `[]` | Volume mounts to add to the distributor pods |
+| distributor.extraVolumes | list | `[]` | Volumes to add to the distributor pods |
+| distributor.image.registry | string | `nil` | The Docker registry for the distributor image. Overrides `loki.image.registry` |
+| distributor.image.repository | string | `nil` | Docker image repository for the distributor image. Overrides `loki.image.repository` |
+| distributor.image.tag | string | `nil` | Docker image tag for the distributor image. Overrides `loki.image.tag` |
+| distributor.nodeSelector | object | `{}` | Node selector for distributor pods |
+| distributor.podAnnotations | object | `{}` | Annotations for distributor pods |
+| distributor.priorityClassName | string | `nil` | The name of the PriorityClass for distributor pods |
+| distributor.replicas | int | `1` | Number of replicas for the distributor |
+| distributor.resources | object | `{}` | Resource requests and limits for the distributor |
+| distributor.terminationGracePeriodSeconds | int | `30` | Grace period to allow the distributor to shutdown before it is killed |
+| distributor.tolerations | list | `[]` | Tolerations for distributor pods |
+| fullnameOverride | string | `nil` | Overrides the chart's computed fullname |
+| gateway.affinity | string | Hard node and soft zone anti-affinity | Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string |
+| gateway.basicAuth.enabled | bool | `false` | Enables basic authentication for the gateway |
+| gateway.basicAuth.existingSecret | string | `nil` | Existing basic auth secret to use. Must contain '.htpasswd' |
+| gateway.basicAuth.password | string | `nil` | The basic auth password for the gateway |
+| gateway.basicAuth.username | string | `nil` | The basic auth username for the gateway |
+| gateway.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for gateway containers |
+| gateway.extraArgs | list | `[]` | Additional CLI args for the gateway |
+| gateway.extraEnv | list | `[]` | Environment variables to add to the gateway pods |
+| gateway.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the gateway pods |
+| gateway.extraVolumeMounts | list | `[]` | Volume mounts to add to the gateway pods |
+| gateway.extraVolumes | list | `[]` | Volumes to add to the gateway pods |
+| gateway.image.pullPolicy | string | `"IfNotPresent"` | The gateway image pull policy |
+| gateway.image.registry | string | `"docker.io"` | The Docker registry for the gateway image |
+| gateway.image.repository | string | `"nginxinc/nginx-unprivileged"` | The gateway image repository |
+| gateway.image.tag | string | `"1.19-alpine"` | The gateway image tag |
+| gateway.ingress.annotations | object | `{}` | Annotations for the gateway ingress |
+| gateway.ingress.enabled | bool | `false` | Specifies whether an ingress for the gateway should be created |
+| gateway.ingress.hosts | list | `[{"host":"gateway.loki.example.com","paths":["/"]}]` | Hosts configuration for the gateway ingress |
+| gateway.ingress.tls | list | `[{"hosts":["gateway.loki.example.com"],"secretName":"loki-gateway-tls"}]` | TLS configuration for the gateway ingress |
+| gateway.nginxConfig | string | See values.yaml | Config file contents for Nginx. Passed through the `tpl` function to allow templating |
+| gateway.nodeSelector | object | `{}` | Node selector for gateway pods |
+| gateway.podAnnotations | object | `{}` | Annotations for gateway pods |
+| gateway.podSecurityContext | object | `{"fsGroup":101,"runAsGroup":101,"runAsNonRoot":true,"runAsUser":101}` | The SecurityContext for gateway containers |
+| gateway.priorityClassName | string | `nil` | The name of the PriorityClass for gateway pods |
+| gateway.readinessProbe.httpGet.path | string | `"/"` |  |
+| gateway.readinessProbe.httpGet.port | string | `"http"` |  |
+| gateway.readinessProbe.initialDelaySeconds | int | `15` |  |
+| gateway.readinessProbe.timeoutSeconds | int | `1` |  |
+| gateway.replicas | int | `1` | Number of replicas for the gateway |
+| gateway.resources | object | `{}` | Resource requests and limits for the gateway |
+| gateway.service.annotations | object | `{}` | Annotations for the gateway service |
+| gateway.service.clusterIP | string | `nil` | ClusterIP of the gateway service |
+| gateway.service.loadBalancerIP | string | `nil` | Load balancer IPO address if service type is LoadBalancer |
+| gateway.service.nodePort | string | `nil` | Node port if service type is NodePort |
+| gateway.service.port | int | `80` | Port of the gateway service |
+| gateway.service.type | string | `"ClusterIP"` | Type of the gateway service |
+| gateway.terminationGracePeriodSeconds | int | `30` | Grace period to allow the gateway to shutdown before it is killed |
+| gateway.tolerations | list | `[]` | Tolerations for gateway pods |
+| global.clusterDomain | string | `"cluster.local"` | configures cluster domain ("cluster.local" by default) |
+| global.dnsService | string | `"kube-dns"` | configures DNS service name in kube-system |
+| global.image.registry | string | `nil` | Overrides the Docker registry globally for all images |
+| global.priorityClassName | string | `nil` | Overrides the priorityClassName for all pods |
+| imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
+| ingester.affinity | string | Hard node and soft zone anti-affinity | Affinity for ingester pods. Passed through `tpl` and, thus, to be configured as string |
+| ingester.extraArgs | list | `[]` | Additional CLI args for the ingester |
+| ingester.extraEnv | list | `[]` | Environment variables to add to the ingester pods |
+| ingester.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the ingester pods |
+| ingester.extraVolumeMounts | list | `[]` | Volume mounts to add to the ingester pods |
+| ingester.extraVolumes | list | `[]` | Volumes to add to the ingester pods |
+| ingester.image.registry | string | `nil` | The Docker registry for the ingester image. Overrides `loki.image.registry` |
+| ingester.image.repository | string | `nil` | Docker image repository for the ingester image. Overrides `loki.image.repository` |
+| ingester.image.tag | string | `nil` | Docker image tag for the ingester image. Overrides `loki.image.tag` |
+| ingester.nodeSelector | object | `{}` | Node selector for ingester pods |
+| ingester.persistence.enabled | bool | `false` | Enable creating PVCs which is required when using boltdb-shipper |
+| ingester.persistence.size | string | `"10Gi"` | Size of persistent disk |
+| ingester.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| ingester.podAnnotations | object | `{}` | Annotations for ingester pods |
+| ingester.priorityClassName | string | `nil` | The name of the PriorityClass for ingester pods |
+| ingester.replicas | int | `1` | Number of replicas for the ingester |
+| ingester.resources | object | `{}` | Resource requests and limits for the ingester |
+| ingester.terminationGracePeriodSeconds | int | `300` | Grace period to allow the ingester to shutdown before it is killed. Especially for the ingestor, this must be increased. It must be long enough so ingesters can be gracefully shutdown flushing/transferring all data and to successfully leave the member ring on shutdown. |
+| ingester.tolerations | list | `[]` | Tolerations for ingester pods |
+| loki.config | string | See values.yaml | Config file contents for Loki |
+| loki.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for Loki containers |
+| loki.image.pullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
+| loki.image.registry | string | `"docker.io"` | The Docker registry |
+| loki.image.repository | string | `"grafana/loki"` | Docker image repository |
+| loki.image.tag | string | `nil` | Overrides the image tag whose default is the chart's appVersion |
+| loki.podAnnotations | object | `{}` | Common annotations for all pods |
+| loki.podSecurityContext | object | `{"fsGroup":10001,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001}` | The SecurityContext for Loki pods |
+| loki.readinessProbe.httpGet.path | string | `"/ready"` |  |
+| loki.readinessProbe.httpGet.port | string | `"http"` |  |
+| loki.readinessProbe.initialDelaySeconds | int | `30` |  |
+| loki.readinessProbe.timeoutSeconds | int | `1` |  |
+| loki.revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback |
+| memcached.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for memcached containers |
+| memcached.image.pullPolicy | string | `"IfNotPresent"` | Memcached Docker image pull policy |
+| memcached.image.registry | string | `"docker.io"` | The Docker registry for the memcached |
+| memcached.image.repository | string | `"memcached"` | Memcached Docker image repository |
+| memcached.image.tag | string | `"1.6.7-alpine"` | Memcached Docker image tag |
+| memcached.podSecurityContext | object | `{"fsGroup":11211,"runAsGroup":11211,"runAsNonRoot":true,"runAsUser":11211}` | The SecurityContext for memcached pods |
+| memcachedChunks.affinity | string | Hard node and soft zone anti-affinity | Affinity for memcached-chunks pods. Passed through `tpl` and, thus, to be configured as string |
+| memcachedChunks.enabled | bool | `false` | Specifies whether the Memcached chunks cache should be enabled |
+| memcachedChunks.extraArgs | list | `[]` | Additional CLI args for memcached-chunks |
+| memcachedChunks.extraEnv | list | `[]` | Environment variables to add to memcached-chunks pods |
+| memcachedChunks.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached-chunks pods |
+| memcachedChunks.nodeSelector | object | `{}` | Node selector for memcached-chunks pods |
+| memcachedChunks.podAnnotations | object | `{}` | Annotations for memcached-chunks pods |
+| memcachedChunks.priorityClassName | string | `nil` | The name of the PriorityClass for memcached-chunks pods |
+| memcachedChunks.replicas | int | `1` | Number of replicas for memcached-chunks |
+| memcachedChunks.resources | object | `{}` | Resource requests and limits for memcached-chunks |
+| memcachedChunks.terminationGracePeriodSeconds | int | `30` | Grace period to allow memcached-chunks to shutdown before it is killed |
+| memcachedChunks.tolerations | list | `[]` | Tolerations for memcached-chunks pods |
+| memcachedExporter.enabled | bool | `false` | Specifies whether the Memcached Exporter should be enabled |
+| memcachedExporter.image.pullPolicy | string | `"IfNotPresent"` | Memcached Exporter Docker image pull policy |
+| memcachedExporter.image.registry | string | `"docker.io"` | The Docker registry for the Memcached Exporter |
+| memcachedExporter.image.repository | string | `"prom/memcached-exporter"` | Memcached Exporter Docker image repository |
+| memcachedExporter.image.tag | string | `"v0.6.0"` | Memcached Exporter Docker image tag |
+| memcachedExporter.resources | object | `{}` | Memcached Exporter resource requests and limits |
+| memcachedFrontend.affinity | string | Hard node and soft zone anti-affinity | Affinity for memcached-frontend pods. Passed through `tpl` and, thus, to be configured as string |
+| memcachedFrontend.enabled | bool | `false` | Specifies whether the Memcached frontend cache should be enabled |
+| memcachedFrontend.extraArgs | list | `[]` | Additional CLI args for memcached-frontend |
+| memcachedFrontend.extraEnv | list | `[]` | Environment variables to add to memcached-frontend pods |
+| memcachedFrontend.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached-frontend pods |
+| memcachedFrontend.nodeSelector | object | `{}` | Node selector for memcached-frontend pods |
+| memcachedFrontend.podAnnotations | object | `{}` | Annotations for memcached-frontend pods |
+| memcachedFrontend.priorityClassName | string | `nil` | The name of the PriorityClass for memcached-frontend pods |
+| memcachedFrontend.replicas | int | `1` | Number of replicas for memcached-frontend |
+| memcachedFrontend.resources | object | `{}` | Resource requests and limits for memcached-frontend |
+| memcachedFrontend.terminationGracePeriodSeconds | int | `30` | Grace period to allow memcached-frontend to shutdown before it is killed |
+| memcachedFrontend.tolerations | list | `[]` | Tolerations for memcached-frontend pods |
+| memcachedIndexQueries.affinity | string | Hard node and soft zone anti-affinity | Affinity for memcached-index-queries pods. Passed through `tpl` and, thus, to be configured as string |
+| memcachedIndexQueries.enabled | bool | `false` | Specifies whether the Memcached index queries cache should be enabled |
+| memcachedIndexQueries.extraArgs | list | `[]` | Additional CLI args for memcached-index-queries |
+| memcachedIndexQueries.extraEnv | list | `[]` | Environment variables to add to memcached-index-queries pods |
+| memcachedIndexQueries.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached-index-queries pods |
+| memcachedIndexQueries.nodeSelector | object | `{}` | Node selector for memcached-index-queries pods |
+| memcachedIndexQueries.podAnnotations | object | `{}` | Annotations for memcached-index-queries pods |
+| memcachedIndexQueries.priorityClassName | string | `nil` | The name of the PriorityClass for memcached-index-queries pods |
+| memcachedIndexQueries.replicas | int | `1` | Number of replicas for memcached-index-queries |
+| memcachedIndexQueries.resources | object | `{}` | Resource requests and limits for memcached-index-queries |
+| memcachedIndexQueries.terminationGracePeriodSeconds | int | `30` | Grace period to allow memcached-index-queries to shutdown before it is killed |
+| memcachedIndexQueries.tolerations | list | `[]` | Tolerations for memcached-index-queries pods |
+| memcachedIndexWrites.affinity | string | Hard node and soft zone anti-affinity | Affinity for memcached-index-writes pods. Passed through `tpl` and, thus, to be configured as string |
+| memcachedIndexWrites.enabled | bool | `false` | Specifies whether the Memcached index writes cache should be enabled |
+| memcachedIndexWrites.extraArgs | list | `[]` | Additional CLI args for memcached-index-writes |
+| memcachedIndexWrites.extraEnv | list | `[]` | Environment variables to add to memcached-index-writes pods |
+| memcachedIndexWrites.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached-index-writes pods |
+| memcachedIndexWrites.nodeSelector | object | `{}` | Node selector for memcached-index-writes pods |
+| memcachedIndexWrites.podAnnotations | object | `{}` | Annotations for memcached-index-writes pods |
+| memcachedIndexWrites.priorityClassName | string | `nil` | The name of the PriorityClass for memcached-index-writes pods |
+| memcachedIndexWrites.replicas | int | `1` | Number of replicas for memcached-index-writes |
+| memcachedIndexWrites.resources | object | `{}` | Resource requests and limits for memcached-index-writes |
+| memcachedIndexWrites.terminationGracePeriodSeconds | int | `30` | Grace period to allow memcached-index-writes to shutdown before it is killed |
+| memcachedIndexWrites.tolerations | list | `[]` | Tolerations for memcached-index-writes pods |
+| nameOverride | string | `nil` | Overrides the chart's name |
+| prometheusRule.annotations | object | `{}` | PrometheusRule annotations |
+| prometheusRule.enabled | bool | `false` | If enabled, a PrometheusRule resource for Prometheus Operator is created |
+| prometheusRule.groups | list | `[]` | Contents of Prometheus rules file |
+| prometheusRule.labels | object | `{}` | Additional PrometheusRule labels |
+| prometheusRule.namespace | string | `nil` | Alternative namespace for the PrometheusRule resource |
+| querier.affinity | string | Hard node and soft zone anti-affinity | Affinity for querier pods. Passed through `tpl` and, thus, to be configured as string |
+| querier.extraArgs | list | `[]` | Additional CLI args for the querier |
+| querier.extraEnv | list | `[]` | Environment variables to add to the querier pods |
+| querier.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the querier pods |
+| querier.extraVolumeMounts | list | `[]` | Volume mounts to add to the querier pods |
+| querier.extraVolumes | list | `[]` | Volumes to add to the querier pods |
+| querier.image.registry | string | `nil` | The Docker registry for the querier image. Overrides `loki.image.registry` |
+| querier.image.repository | string | `nil` | Docker image repository for the querier image. Overrides `loki.image.repository` |
+| querier.image.tag | string | `nil` | Docker image tag for the querier image. Overrides `loki.image.tag` |
+| querier.nodeSelector | object | `{}` | Node selector for querier pods |
+| querier.persistence.enabled | bool | `false` | Enable creating PVCs for the querier cache |
+| querier.persistence.size | string | `"10Gi"` | Size of persistent disk |
+| querier.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| querier.podAnnotations | object | `{}` | Annotations for querier pods |
+| querier.priorityClassName | string | `nil` | The name of the PriorityClass for querier pods |
+| querier.replicas | int | `1` | Number of replicas for the querier |
+| querier.resources | object | `{}` | Resource requests and limits for the querier |
+| querier.terminationGracePeriodSeconds | int | `30` | Grace period to allow the querier to shutdown before it is killed |
+| querier.tolerations | list | `[]` | Tolerations for querier pods |
+| queryFrontend.affinity | string | Hard node and soft zone anti-affinity | Affinity for query-frontend pods. Passed through `tpl` and, thus, to be configured as string |
+| queryFrontend.extraArgs | list | `[]` | Additional CLI args for the query-frontend |
+| queryFrontend.extraEnv | list | `[]` | Environment variables to add to the query-frontend pods |
+| queryFrontend.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the query-frontend pods |
+| queryFrontend.extraVolumeMounts | list | `[]` | Volume mounts to add to the query-frontend pods |
+| queryFrontend.extraVolumes | list | `[]` | Volumes to add to the query-frontend pods |
+| queryFrontend.image.registry | string | `nil` | The Docker registry for the query-frontend image. Overrides `loki.image.registry` |
+| queryFrontend.image.repository | string | `nil` | Docker image repository for the query-frontend image. Overrides `loki.image.repository` |
+| queryFrontend.image.tag | string | `nil` | Docker image tag for the query-frontend image. Overrides `loki.image.tag` |
+| queryFrontend.nodeSelector | object | `{}` | Node selector for query-frontend pods |
+| queryFrontend.podAnnotations | object | `{}` | Annotations for query-frontend pods |
+| queryFrontend.priorityClassName | string | `nil` | The name of the PriorityClass for query-frontend pods |
+| queryFrontend.replicas | int | `1` | Number of replicas for the query-frontend |
+| queryFrontend.resources | object | `{}` | Resource requests and limits for the query-frontend |
+| queryFrontend.terminationGracePeriodSeconds | int | `30` | Grace period to allow the query-frontend to shutdown before it is killed |
+| queryFrontend.tolerations | list | `[]` | Tolerations for query-frontend pods |
+| rbac.pspEnabled | bool | `false` | If enabled, a PodSecurityPolicy is created |
+| ruler.affinity | string | Hard node and soft zone anti-affinity | Affinity for ruler pods. Passed through `tpl` and, thus, to be configured as string |
+| ruler.directories | object | `{}` | Directories containing rules files |
+| ruler.enabled | bool | `false` | Specifies whether the ruler should be enabled |
+| ruler.extraArgs | list | `[]` | Additional CLI args for the ruler |
+| ruler.extraEnv | list | `[]` | Environment variables to add to the ruler pods |
+| ruler.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the ruler pods |
+| ruler.extraVolumeMounts | list | `[]` | Volume mounts to add to the ruler pods |
+| ruler.extraVolumes | list | `[]` | Volumes to add to the ruler pods |
+| ruler.image.registry | string | `nil` | The Docker registry for the ruler image. Overrides `loki.image.registry` |
+| ruler.image.repository | string | `nil` | Docker image repository for the ruler image. Overrides `loki.image.repository` |
+| ruler.image.tag | string | `nil` | Docker image tag for the ruler image. Overrides `loki.image.tag` |
+| ruler.nodeSelector | object | `{}` | Node selector for ruler pods |
+| ruler.persistence.enabled | bool | `false` | Enable creating PVCs for the ruler |
+| ruler.persistence.size | string | `"10Gi"` | Size of persistent disk |
+| ruler.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
+| ruler.podAnnotations | object | `{}` | Annotations for ruler pods |
+| ruler.priorityClassName | string | `nil` | The name of the PriorityClass for ruler pods |
+| ruler.replicas | int | `1` | Number of replicas for the ruler |
+| ruler.resources | object | `{}` | Resource requests and limits for the ruler |
+| ruler.terminationGracePeriodSeconds | int | `300` | Grace period to allow the ruler to shutdown before it is killed |
+| ruler.tolerations | list | `[]` | Tolerations for ruler pods |
+| serviceAccount.annotations | object | `{}` | Annotations for the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |
+| serviceAccount.imagePullSecrets | list | `[]` | Image pull secrets for the service account |
+| serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor.annotations | object | `{}` | ServiceMonitor annotations |
+| serviceMonitor.enabled | bool | `false` | If enabled, ServiceMonitor resources for Prometheus Operator are created |
+| serviceMonitor.interval | string | `nil` | ServiceMonitor scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
+| serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor resources |
+| serviceMonitor.namespaceSelector | object | `{}` | Namespace selector for ServiceMonitor resources |
+| serviceMonitor.scheme | string | `"http"` | ServiceMonitor will use http by default, but you can pick https as well |
+| serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
+| serviceMonitor.tlsConfig | string | `nil` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
+| tableManager.affinity | string | Hard node and soft zone anti-affinity | Affinity for table-manager pods. Passed through `tpl` and, thus, to be configured as string |
+| tableManager.enabled | bool | `false` | Specifies whether the table-manager should be enabled |
+| tableManager.extraArgs | list | `[]` | Additional CLI args for the table-manager |
+| tableManager.extraEnv | list | `[]` | Environment variables to add to the table-manager pods |
+| tableManager.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the table-manager pods |
+| tableManager.extraVolumeMounts | list | `[]` | Volume mounts to add to the table-manager pods |
+| tableManager.extraVolumes | list | `[]` | Volumes to add to the table-manager pods |
+| tableManager.image.registry | string | `nil` | The Docker registry for the table-manager image. Overrides `loki.image.registry` |
+| tableManager.image.repository | string | `nil` | Docker image repository for the table-manager image. Overrides `loki.image.repository` |
+| tableManager.image.tag | string | `nil` | Docker image tag for the table-manager image. Overrides `loki.image.tag` |
+| tableManager.nodeSelector | object | `{}` | Node selector for table-manager pods |
+| tableManager.podAnnotations | object | `{}` | Annotations for table-manager pods |
+| tableManager.priorityClassName | string | `nil` | The name of the PriorityClass for table-manager pods |
+| tableManager.replicas | int | `1` | Number of replicas for the table-manager |
+| tableManager.resources | object | `{}` | Resource requests and limits for the table-manager |
+| tableManager.terminationGracePeriodSeconds | int | `30` | Grace period to allow the table-manager to shutdown before it is killed |
+| tableManager.tolerations | list | `[]` | Tolerations for table-manager pods |
+
+## Components
+
+The chart supports the compontents shown in the following table.
+Gateway, ingester, distributor, querier, and query-frontend are always installed.
+The other components are optional and must be explicitly enabled.
+
+| Component | Optional |
+| --- | --- |
+| gateway | no |
+| ingester | no |
+| distributor | no |
+| querier | no |
+| query-frontend | no |
+| table-manager | yes |
+| compactor | yes |
+| ruler | yes |
+| memcached-chunks | yes |
+| memcached-frontend | yes |
+| memcached-index-queries | yes |
+| memcached-index-writes | yes |
+
+## Configuration
+
+This chart configures Loki in microservices mode.
+It has been tested to work with [boltdb-shipper](https://grafana.com/docs/loki/latest/operations/storage/boltdb-shipper/)
+and [memberlist](https://grafana.com/docs/loki/latest/configuration/#memberlist_config) while other storage and discovery options should work as well.
+However, the chart does not support setting up Consul or Etcd for discovery,
+and it is not intended to support these going forward.
+They would have to be set up separately.
+Instead, memberlist can be used which does not require a separate key/value store.
+The chart creates a headless service for the memberlist which ingester, distributor, querier, and ruler are part of.
+
+----
+
+**NOTE:**
+In its default configuration, the chart uses `boltdb-shipper` and `filesystem` as storage.
+The reason for this is that the chart can be validated and installed in a CI pipeline.
+However, this setup is not fully functional.
+Querying will not be possible (or limited to the ingesters' in-memory caches) because that would otherwise require shared storage between ingesters and queriers
+which the chart does not support and would require a volume that supports `ReadWriteMany` access mode anyways.
+The recommendation is to use object storage, such as S3, GCS, MinIO, etc., or one of the other options documented at https://grafana.com/docs/loki/latest/storage/.
+
+Alternatively, in order to quickly test Loki using the filestore, the [single binary chart](https://github.com/grafana/helm-charts/tree/main/charts/loki) can be used.
+
+----
+
+### Directory and File Locations
+
+* Volumes are mounted to `/var/loki`. The various directories Loki needs should be configured as subdirectories (e. g. `/var/loki/index`, `/var/loki/cache`). Loki will create the directories automatically.
+* The config file is mounted to `/etc/loki/config/config.yaml` and passed as CLI arg.
+
+### Example configuration using memberlist, boltdb-shipper, and S3 for storage
+
+Note that `loki.config` must be configured as string.
+That's required because it is passed through the `tpl` function in order to support templating.
+This means that a complete configuration needs to be supplied to the charts which is a good thing anyways.
+Also, this allows using a separate YAML file which can be passed in using `--set-file loki.config=/path/to/config.yaml`.
+
+```yaml
+loki:
+  config: |
+    server:
+      log_level: info
+      # Must be set to 3100
+      http_listen_port: 3100
+
+    distributor:
+      ring:
+        kvstore:
+          store: memberlist
+
+    ingester:
+      # Disable chunk transfer which is not possible with statefulsets
+      # and unnecessary for boltdb-shipper
+      max_transfer_retries: 0
+      chunk_idle_period: 1h
+      chunk_target_size: 1536000
+      max_chunk_age: 1h
+      lifecycler:
+        join_after: 0s
+        ring:
+          kvstore:
+            store: memberlist
+
+    memberlist:
+      join_members:
+        - {{ include "loki.fullname" . }}-memberlist
+
+    limits_config:
+      ingestion_rate_mb: 10
+      ingestion_burst_size_mb: 20
+      max_concurrent_tail_requests: 20
+      max_cache_freshness_per_query: 10m
+
+    schema_config:
+      configs:
+        - from: 2020-09-07
+          store: boltdb-shipper
+          object_store: aws
+          schema: v11
+          index:
+            prefix: loki_index_
+            period: 24h
+
+    storage_config:
+      aws:
+        s3: s3://eu-central-1
+        bucketnames: my-loki-s3-bucket
+      boltdb_shipper:
+        active_index_directory: /var/loki/index
+        shared_store: s3
+        cache_location: /var/loki/cache
+
+    query_range:
+      # make queries more cache-able by aligning them with their step intervals
+      align_queries_with_step: true
+      max_retries: 5
+      # parallelize queries in 15min intervals
+      split_queries_by_interval: 15m
+      cache_results: true
+
+      results_cache:
+        cache:
+          enable_fifocache: true
+          fifocache:
+            max_size_items: 1024
+            validity: 24h
+
+    frontend_worker:
+      frontend_address: {{ include "loki.queryFrontendFullname" . }}:9095
+
+    frontend:
+      log_queries_longer_than: 5s
+      compress_responses: true
+```
+
+Because the config file is templated, it is also possible to e.g. externalize S3 bucket names:
+
+```yaml
+loki:
+  config: |
+    storage_config:
+      aws:
+        s3: s3://eu-central-1
+        bucketnames: {{ .Values.bucketnames }}
+```
+
+```console
+helm upgrade loki --install -f values.yaml --set bucketnames=my-loki-bucket
+```
+
+## Metrics
+
+Loki exposes Prometheus metrics.
+The chart can create ServiceMonitor objects for all Loki components.
+
+```yaml
+serviceMonitor:
+  enabled: true
+```
+
+Furthermore, it is possible to add Prometheus rules:
+
+```yaml
+prometheusRule:
+  enabled: true
+  groups:
+    - name: loki-rules
+      rules:
+        - record: job:loki_request_duration_seconds_bucket:sum_rate
+          expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job)
+        - record: job_route:loki_request_duration_seconds_bucket:sum_rate
+          expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job, route)
+        - record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
+          expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
+```
+
+## Caching
+
+The chart can configure up to four Memcached instances for the various caches Lokis can use.
+Configuration works the same for all caches.
+The configuration of `memcached-chunks` below demonstrates setting additional options.
+
+Exporters for the Memcached instances can be configured as well.
+
+```yaml
+memcachedExporter:
+  enabled: true
+```
+
+### memcached-chunks
+
+```yaml
+memcachedChunks:
+  enabled: true
+  replicas: 2
+  extraArgs:
+    - -m 2048
+    - -I 2m
+    - -v
+  resources:
+    requests:
+      cpu: 500m
+      memory: 3Gi
+    limits:
+      cpu: "2"
+      memory: 3Gi
+
+loki:
+  config: |
+    chunk_store_config:
+      chunk_cache_config:
+        memcached:
+          batch_size: 100
+          parallelism: 100
+        memcached_client:
+          consistent_hash: true
+          host: {{ include "loki.memcachedChunksFullname" . }}
+          service: http
+```
+
+### memcached-frontend
+
+```yaml
+memcachedFrontend:
+  enabled: true
+
+loki:
+  config: |
+    query_range:
+      cache_results: true
+      results_cache:
+        cache:
+          memcached_client:
+            consistent_hash: true
+            host: {{ include "loki.memcachedFrontendFullname" . }}
+            max_idle_conns: 16
+            service: http
+            timeout: 500ms
+            update_interval: 1m
+```
+
+### memcached-index-queries
+
+```yaml
+memcachedIndexQueries:
+  enabled: true
+
+loki:
+  config: |
+    storage_config:
+      index_queries_cache_config:
+        memcached:
+          batch_size: 100
+          parallelism: 100
+        memcached_client:
+          consistent_hash: true
+          host: {{ include "loki.memcachedIndexQueriesFullname" . }}
+          service: http
+```
+
+### memcached-index-writes
+
+NOTE: This cache is not used with `boltdb-shipper` and should not be enabled in that case.
+
+```yaml
+memcachedIndexWrite:
+  enabled: true
+
+loki:
+  config: |
+    chunk_store_config:
+      write_dedupe_cache_config:
+        memcached:
+          batch_size: 100
+          parallelism: 100
+        memcached_client:
+          consistent_hash: true
+          host: {{ include "loki.memcachedIndexWritesFullname" . }}
+          service: http
+```
+
+## Compactor
+
+Compactor is an optional component which must explicitly be enabled.
+The chart automatically sets the correct working directory as command-line arg.
+The correct storage backend must be configured, e.g. `s3`.
+
+```yaml
+compactor:
+  enabled: true
+
+loki:
+  config: |
+    compactor:
+      shared_store: s3
+```
+
+## Ruler
+
+Ruler is an optional component which must explicitly be enabled.
+In addition to installing the ruler, the chart also supports creating rules.
+Rules files must be added to directories named after the tenants.
+See `values.yaml` for a more detailed example.
+
+```yaml
+ruler:
+  enabled: true
+  directories:
+    fake:
+      rules.txt: |
+        groups:
+          - name: should_fire
+            rules:
+              - alert: HighPercentageError
+                expr: |
+                  sum(rate({app="loki"} |= "error" [5m])) by (job)
+                    /
+                  sum(rate({app="loki"}[5m])) by (job)
+                    > 0.05
+                for: 10m
+                labels:
+                  severity: warning
+                annotations:
+                  summary: High error percentage
+```

--- a/charts/loki-distributed/README.md.gotmpl
+++ b/charts/loki-distributed/README.md.gotmpl
@@ -1,0 +1,348 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Chart Repo
+
+Add the following repo to use the chart:
+
+```console
+helm repo add grafana https://grafana.github.io/helm-charts
+```
+
+{{ template "chart.valuesSection" . }}
+
+
+## Components
+
+The chart supports the compontents shown in the following table.
+Gateway, ingester, distributor, querier, and query-frontend are always installed.
+The other components are optional and must be explicitly enabled.
+
+| Component | Optional |
+| --- | --- |
+| gateway | no |
+| ingester | no |
+| distributor | no |
+| querier | no |
+| query-frontend | no |
+| table-manager | yes |
+| compactor | yes |
+| ruler | yes |
+| memcached-chunks | yes |
+| memcached-frontend | yes |
+| memcached-index-queries | yes |
+| memcached-index-writes | yes |
+
+
+## Configuration
+
+This chart configures Loki in microservices mode.
+It has been tested to work with [boltdb-shipper](https://grafana.com/docs/loki/latest/operations/storage/boltdb-shipper/)
+and [memberlist](https://grafana.com/docs/loki/latest/configuration/#memberlist_config) while other storage and discovery options should work as well.
+However, the chart does not support setting up Consul or Etcd for discovery,
+and it is not intended to support these going forward.
+They would have to be set up separately.
+Instead, memberlist can be used which does not require a separate key/value store.
+The chart creates a headless service for the memberlist which ingester, distributor, querier, and ruler are part of.
+
+----
+
+**NOTE:**
+In its default configuration, the chart uses `boltdb-shipper` and `filesystem` as storage.
+The reason for this is that the chart can be validated and installed in a CI pipeline.
+However, this setup is not fully functional.
+Querying will not be possible (or limited to the ingesters' in-memory caches) because that would otherwise require shared storage between ingesters and queriers
+which the chart does not support and would require a volume that supports `ReadWriteMany` access mode anyways.
+The recommendation is to use object storage, such as S3, GCS, MinIO, etc., or one of the other options documented at https://grafana.com/docs/loki/latest/storage/.
+
+Alternatively, in order to quickly test Loki using the filestore, the [single binary chart](https://github.com/grafana/helm-charts/tree/main/charts/loki) can be used.
+
+----
+
+### Directory and File Locations
+
+* Volumes are mounted to `/var/loki`. The various directories Loki needs should be configured as subdirectories (e. g. `/var/loki/index`, `/var/loki/cache`). Loki will create the directories automatically.
+* The config file is mounted to `/etc/loki/config/config.yaml` and passed as CLI arg.
+
+### Example configuration using memberlist, boltdb-shipper, and S3 for storage
+
+Note that `loki.config` must be configured as string.
+That's required because it is passed through the `tpl` function in order to support templating.
+This means that a complete configuration needs to be supplied to the charts which is a good thing anyways.
+Also, this allows using a separate YAML file which can be passed in using `--set-file loki.config=/path/to/config.yaml`.
+
+```yaml
+loki:
+  config: |
+    server:
+      log_level: info
+      # Must be set to 3100
+      http_listen_port: 3100
+
+    distributor:
+      ring:
+        kvstore:
+          store: memberlist
+
+    ingester:
+      # Disable chunk transfer which is not possible with statefulsets
+      # and unnecessary for boltdb-shipper
+      max_transfer_retries: 0
+      chunk_idle_period: 1h
+      chunk_target_size: 1536000
+      max_chunk_age: 1h
+      lifecycler:
+        join_after: 0s
+        ring:
+          kvstore:
+            store: memberlist
+
+    memberlist:
+      join_members:
+        - {{"{{"}} include "loki.fullname" . {{"}}"}}-memberlist
+
+    limits_config:
+      ingestion_rate_mb: 10
+      ingestion_burst_size_mb: 20
+      max_concurrent_tail_requests: 20
+      max_cache_freshness_per_query: 10m
+
+    schema_config:
+      configs:
+        - from: 2020-09-07
+          store: boltdb-shipper
+          object_store: aws
+          schema: v11
+          index:
+            prefix: loki_index_
+            period: 24h
+
+    storage_config:
+      aws:
+        s3: s3://eu-central-1
+        bucketnames: my-loki-s3-bucket
+      boltdb_shipper:
+        active_index_directory: /var/loki/index
+        shared_store: s3
+        cache_location: /var/loki/cache
+
+    query_range:
+      # make queries more cache-able by aligning them with their step intervals
+      align_queries_with_step: true
+      max_retries: 5
+      # parallelize queries in 15min intervals
+      split_queries_by_interval: 15m
+      cache_results: true
+
+      results_cache:
+        cache:
+          enable_fifocache: true
+          fifocache:
+            max_size_items: 1024
+            validity: 24h
+
+    frontend_worker:
+      frontend_address: {{"{{"}} include "loki.queryFrontendFullname" . {{"}}"}}:9095
+
+    frontend:
+      log_queries_longer_than: 5s
+      compress_responses: true
+```
+
+Because the config file is templated, it is also possible to e.g. externalize S3 bucket names:
+
+```yaml
+loki:
+  config: |
+    storage_config:
+      aws:
+        s3: s3://eu-central-1
+        bucketnames: {{"{{"}} .Values.bucketnames {{"}}"}}
+```
+
+```console
+helm upgrade loki --install -f values.yaml --set bucketnames=my-loki-bucket
+```
+
+## Metrics
+
+Loki exposes Prometheus metrics.
+The chart can create ServiceMonitor objects for all Loki components.
+
+```yaml
+serviceMonitor:
+  enabled: true
+```
+
+Furthermore, it is possible to add Prometheus rules:
+
+```yaml
+prometheusRule:
+  enabled: true
+  groups:
+    - name: loki-rules
+      rules:
+        - record: job:loki_request_duration_seconds_bucket:sum_rate
+          expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job)
+        - record: job_route:loki_request_duration_seconds_bucket:sum_rate
+          expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job, route)
+        - record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
+          expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
+```
+
+## Caching
+
+The chart can configure up to four Memcached instances for the various caches Lokis can use.
+Configuration works the same for all caches.
+The configuration of `memcached-chunks` below demonstrates setting additional options.
+
+Exporters for the Memcached instances can be configured as well.
+
+```yaml
+memcachedExporter:
+  enabled: true
+```
+
+### memcached-chunks
+
+```yaml
+memcachedChunks:
+  enabled: true
+  replicas: 2
+  extraArgs:
+    - -m 2048
+    - -I 2m
+    - -v
+  resources:
+    requests:
+      cpu: 500m
+      memory: 3Gi
+    limits:
+      cpu: "2"
+      memory: 3Gi
+
+loki:
+  config: |
+    chunk_store_config:
+      chunk_cache_config:
+        memcached:
+          batch_size: 100
+          parallelism: 100
+        memcached_client:
+          consistent_hash: true
+          host: {{"{{"}} include "loki.memcachedChunksFullname" . {{"}}"}}
+          service: http
+```
+
+### memcached-frontend
+
+```yaml
+memcachedFrontend:
+  enabled: true
+
+loki:
+  config: |
+    query_range:
+      cache_results: true
+      results_cache:
+        cache:
+          memcached_client:
+            consistent_hash: true
+            host: {{"{{"}} include "loki.memcachedFrontendFullname" . {{"}}"}}
+            max_idle_conns: 16
+            service: http
+            timeout: 500ms
+            update_interval: 1m
+```
+
+### memcached-index-queries
+
+```yaml
+memcachedIndexQueries:
+  enabled: true
+
+loki:
+  config: |
+    storage_config:
+      index_queries_cache_config:
+        memcached:
+          batch_size: 100
+          parallelism: 100
+        memcached_client:
+          consistent_hash: true
+          host: {{"{{"}} include "loki.memcachedIndexQueriesFullname" . {{"}}"}}
+          service: http
+```
+
+### memcached-index-writes
+
+NOTE: This cache is not used with `boltdb-shipper` and should not be enabled in that case.
+
+```yaml
+memcachedIndexWrite:
+  enabled: true
+
+loki:
+  config: |
+    chunk_store_config:
+      write_dedupe_cache_config:
+        memcached:
+          batch_size: 100
+          parallelism: 100
+        memcached_client:
+          consistent_hash: true
+          host: {{"{{"}} include "loki.memcachedIndexWritesFullname" . {{"}}"}}
+          service: http
+```
+
+## Compactor
+
+Compactor is an optional component which must explicitly be enabled.
+The chart automatically sets the correct working directory as command-line arg.
+The correct storage backend must be configured, e.g. `s3`.
+
+```yaml
+compactor:
+  enabled: true
+
+loki:
+  config: |
+    compactor:
+      shared_store: s3
+```
+
+## Ruler
+
+Ruler is an optional component which must explicitly be enabled.
+In addition to installing the ruler, the chart also supports creating rules.
+Rules files must be added to directories named after the tenants.
+See `values.yaml` for a more detailed example.
+
+```yaml
+ruler:
+  enabled: true
+  directories:
+    fake:
+      rules.txt: |
+        groups:
+          - name: should_fire
+            rules:
+              - alert: HighPercentageError
+                expr: |
+                  sum(rate({app="loki"} |= "error" [5m])) by (job)
+                    /
+                  sum(rate({app="loki"}[5m])) by (job)
+                    > 0.05
+                for: 10m
+                labels:
+                  severity: warning
+                annotations:
+                  summary: High error percentage
+```

--- a/charts/loki-distributed/ci/cache-values.yaml
+++ b/charts/loki-distributed/ci/cache-values.yaml
@@ -1,0 +1,111 @@
+loki:
+  config: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+
+    distributor:
+      ring:
+        kvstore:
+          store: memberlist
+
+    memberlist:
+      join_members:
+        - {{ include "loki.fullname" . }}-memberlist
+
+    ingester:
+      lifecycler:
+        ring:
+          kvstore:
+            store: memberlist
+          replication_factor: 1
+      chunk_idle_period: 30m
+      chunk_block_size: 262144
+      chunk_retain_period: 1m
+      max_transfer_retries: 0
+
+    limits_config:
+      enforce_metric_name: false
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+      ingestion_burst_size_mb: 20
+      ingestion_rate_mb: 10
+
+    schema_config:
+      configs:
+        - from: 2020-09-07
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: loki_index_
+            period: 24h
+
+    storage_config:
+      boltdb_shipper:
+        shared_store: filesystem
+        active_index_directory: /var/loki/index
+        cache_location: /var/loki/cache
+        cache_ttl: 168h
+      filesystem:
+        directory: /var/loki/chunks
+      index_queries_cache_config:
+        memcached:
+          batch_size: 100
+          parallelism: 100
+        memcached_client:
+          consistent_hash: true
+          host: {{ include "loki.memcachedIndexQueriesFullname" . }}
+          service: http
+
+    chunk_store_config:
+      max_look_back_period: 0
+      chunk_cache_config:
+        memcached:
+          batch_size: 100
+          parallelism: 100
+        memcached_client:
+          consistent_hash: true
+          host: {{ include "loki.memcachedChunksFullname" . }}
+          service: http
+
+    query_range:
+      align_queries_with_step: true
+      max_retries: 5
+      split_queries_by_interval: 30m
+      cache_results: true
+      results_cache:
+        cache:
+          memcached_client:
+            consistent_hash: true
+            host: {{ include "loki.memcachedFrontendFullname" . }}
+            max_idle_conns: 16
+            service: http
+            timeout: 500ms
+            update_interval: 1m
+
+    frontend_worker:
+      frontend_address: {{ include "loki.queryFrontendFullname" . }}:9095
+
+    frontend:
+      log_queries_longer_than: 5s
+      compress_responses: true
+
+memcachedExporter:
+  enabled: true
+
+memcachedChunks:
+  enabled: true
+  extraArgs:
+    - -vv
+
+memcachedFrontend:
+  enabled: true
+  extraArgs:
+    - -vv
+
+memcachedIndexQueries:
+  enabled: true
+  extraArgs:
+    - -vv

--- a/charts/loki-distributed/ci/persistence-values.yaml
+++ b/charts/loki-distributed/ci/persistence-values.yaml
@@ -1,0 +1,15 @@
+ingester:
+  persistence:
+    enabled: true
+    size: 100Mi
+
+querier:
+  persistence:
+    enabled: true
+    size: 100Mi
+
+gateway:
+  basicAuth:
+    enabled: true
+    username: user
+    password: pass

--- a/charts/loki-distributed/templates/NOTES.txt
+++ b/charts/loki-distributed/templates/NOTES.txt
@@ -1,0 +1,33 @@
+***********************************************************************
+ Welcome to Grafana Loki
+ Chart version: {{ .Chart.Version }}
+ Loki version: {{ .Chart.AppVersion }}
+***********************************************************************
+
+Installed components:
+* gateway
+* ingester
+* distributor
+* querier
+* query-frontend
+{{- if .Values.tableManager.enabled }}
+* table-manager
+{{- end }}
+{{- if .Values.compactor.enabled }}
+* compactor
+{{- end }}
+{{- if .Values.ruler.enabled }}
+* ruler
+{{- end }}
+{{- if .Values.memcachedChunks.enabled }}
+* memcached-chunks
+{{- end }}
+{{- if .Values.memcachedFrontend.enabled }}
+* memcached-frontend
+{{- end }}
+{{- if .Values.memcachedIndexQueries.enabled }}
+* memcached-index-queries
+{{- end }}
+{{- if .Values.memcachedIndexWrites.enabled }}
+* memcached-index-writes
+{{- end }}

--- a/charts/loki-distributed/templates/_helpers.tpl
+++ b/charts/loki-distributed/templates/_helpers.tpl
@@ -1,0 +1,97 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "loki.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "loki.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "loki.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "loki.labels" -}}
+helm.sh/chart: {{ include "loki.chart" . }}
+{{ include "loki.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "loki.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "loki.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "loki.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "loki.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Docker image name for Loki
+*/}}
+{{- define "loki.lokiImage" -}}
+{{- $registry := coalesce .global.registry .service.registry .loki.registry -}}
+{{- $repository := coalesce .service.repository .loki.repository -}}
+{{- $tag := coalesce .service.tag .loki.tag .defaultVersion | toString -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end -}}
+
+{{/*
+Docker image name
+*/}}
+{{- define "loki.image" -}}
+{{- $registry := coalesce .global.registry .service.registry -}}
+{{- $tag := .service.tag | toString -}}
+{{- printf "%s/%s:%s" $registry .service.repository (.service.tag | toString) -}}
+{{- end -}}
+
+{{/*
+Memcached Docker image
+*/}}
+{{- define "loki.memcachedImage" -}}
+{{- $dict := dict "service" .Values.memcached.image "global" .Values.global.image -}}
+{{- include "loki.image" $dict -}}
+{{- end }}
+
+{{/*
+Memcached Exporter Docker image
+*/}}
+{{- define "loki.memcachedExporterImage" -}}
+{{- $dict := dict "service" .Values.memcachedExporter.image "global" .Values.global.image -}}
+{{- include "loki.image" $dict -}}
+{{- end }}

--- a/charts/loki-distributed/templates/compactor/_helpers-compactor.tpl
+++ b/charts/loki-distributed/templates/compactor/_helpers-compactor.tpl
@@ -1,0 +1,40 @@
+{{/*
+compactor fullname
+*/}}
+{{- define "loki.compactorFullname" -}}
+{{ include "loki.fullname" . }}-compactor
+{{- end }}
+
+{{/*
+compactor common labels
+*/}}
+{{- define "loki.compactorLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: compactor
+{{- end }}
+
+{{/*
+compactor selector labels
+*/}}
+{{- define "loki.compactorSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: compactor
+{{- end }}
+
+{{/*
+compactor image
+*/}}
+{{- define "loki.compactorImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.compactor.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}
+
+{{/*
+compactor priority class name
+*/}}
+{{- define "loki.compactorPriorityClassName" }}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.compactor.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/deployment-compactor.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.compactor.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki.compactorFullname" . }}
+  labels:
+    {{- include "loki.compactorLabels" . | nindent 4 }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "loki.compactorSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.compactor.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.compactorSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.compactorPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.compactor.terminationGracePeriodSeconds }}
+      containers:
+        - name: loki
+          image: {{ include "loki.compactorImage" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=compactor
+            - -boltdb.shipper.compactor.working-directory=/var/loki/compactor
+            {{- with .Values.compactor.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+          {{- with .Values.compactor.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.compactor.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            - name: data
+              mountPath: /var/loki
+            {{- with .Values.compactor.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.compactor.resources | nindent 12 }}
+      {{- with .Values.compactor.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.compactor.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "loki.fullname" . }}
+        - name: data
+          {{- if .Values.compactor.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: data-{{ include "loki.compactorFullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.compactor.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/compactor/persistentvolumeclaim-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/persistentvolumeclaim-compactor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.compactor.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-{{ include "loki.compactorFullname" . }}
+  labels:
+    {{- include "loki.compactorLabels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.compactor.persistence.storageClass }}
+  storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: "{{ .Values.compactor.persistence.size }}"
+{{- end }}

--- a/charts/loki-distributed/templates/compactor/service-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/service-compactor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.compactor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.compactorFullname" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "loki.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: compactor
+{{- end }}

--- a/charts/loki-distributed/templates/compactor/servicemonitor-compactor.yaml
+++ b/charts/loki-distributed/templates/compactor/servicemonitor-compactor.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.compactor.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.compactorFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.compactorLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.compactorSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/configmap.yaml
+++ b/charts/loki-distributed/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "loki.fullname" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- tpl .Values.loki.config . | nindent 4 }}

--- a/charts/loki-distributed/templates/distributor/_helpers-distributor.tpl
+++ b/charts/loki-distributed/templates/distributor/_helpers-distributor.tpl
@@ -1,0 +1,40 @@
+{{/*
+distributor fullname
+*/}}
+{{- define "loki.distributorFullname" -}}
+{{ include "loki.fullname" . }}-distributor
+{{- end }}
+
+{{/*
+distributor common labels
+*/}}
+{{- define "loki.distributorLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: distributor
+{{- end }}
+
+{{/*
+distributor selector labels
+*/}}
+{{- define "loki.distributorSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: distributor
+{{- end }}
+
+{{/*
+distributor image
+*/}}
+{{- define "loki.distributorImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.distributor.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}
+
+{{/*
+distributor priority class name
+*/}}
+{{- define "loki.distributorPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.distributor.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/deployment-distributor.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki.distributorFullname" . }}
+  labels:
+    {{- include "loki.distributorLabels" . | nindent 4 }}
+    app.kubernetes.io/part-of: memberlist
+spec:
+  replicas: {{ .Values.distributor.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.distributorSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.distributor.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.distributorSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.distributorPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.distributor.terminationGracePeriodSeconds }}
+      containers:
+        - name: loki
+          image: {{ include "loki.distributorImage" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=distributor
+            {{- with .Values.distributor.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
+          {{- with .Values.distributor.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.distributor.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            {{- with .Values.distributor.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.distributor.resources | nindent 12 }}
+      {{- with .Values.distributor.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.distributor.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.distributor.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "loki.fullname" . }}
+        {{- with .Values.distributor.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/poddisruptionbudget-distributor.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.distributor.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.distributorFullname" . }}
+  labels:
+    {{- include "loki.distributorLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.distributorSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/loki-distributed/templates/distributor/service-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/service-distributor.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.distributorFullname" . }}
+  labels:
+    {{- include "loki.distributorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.distributorSelectorLabels" . | nindent 4 }}

--- a/charts/loki-distributed/templates/distributor/servicemonitor-distributor.yaml
+++ b/charts/loki-distributed/templates/distributor/servicemonitor-distributor.yaml
@@ -1,0 +1,43 @@
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.distributorFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.distributorLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.distributorSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/ingester/_helpers-ingester.tpl
+++ b/charts/loki-distributed/templates/ingester/_helpers-ingester.tpl
@@ -1,0 +1,40 @@
+{{/*
+ingester fullname
+*/}}
+{{- define "loki.ingesterFullname" -}}
+{{ include "loki.fullname" . }}-ingester
+{{- end }}
+
+{{/*
+ingester common labels
+*/}}
+{{- define "loki.ingesterLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: ingester
+{{- end }}
+
+{{/*
+ingester selector labels
+*/}}
+{{- define "loki.ingesterSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: ingester
+{{- end }}
+
+{{/*
+ingester image
+*/}}
+{{- define "loki.ingesterImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.ingester.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}
+
+{{/*
+ingester priority class name
+*/}}
+{{- define "loki.ingesterPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.ingester.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/poddisruptionbudget-ingester.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.ingester.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.ingesterFullname" . }}
+  labels:
+    {{- include "loki.ingesterLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.ingesterSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/loki-distributed/templates/ingester/service-ingester-headless.yaml
+++ b/charts/loki-distributed/templates/ingester/service-ingester-headless.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.ingesterFullname" . }}-headless
+  labels:
+    {{- include "loki.ingesterSelectorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.ingesterSelectorLabels" . | nindent 4 }}

--- a/charts/loki-distributed/templates/ingester/service-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/service-ingester.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.ingesterFullname" . }}
+  labels:
+    {{- include "loki.ingesterLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.ingesterSelectorLabels" . | nindent 4 }}

--- a/charts/loki-distributed/templates/ingester/servicemonitor-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/servicemonitor-ingester.yaml
@@ -1,0 +1,43 @@
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.ingesterFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.ingesterLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.ingesterSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
+++ b/charts/loki-distributed/templates/ingester/statefulset-ingester.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "loki.ingesterFullname" . }}
+  labels:
+    {{- include "loki.ingesterLabels" . | nindent 4 }}
+    app.kubernetes.io/part-of: memberlist
+spec:
+  replicas: {{ .Values.ingester.replicas }}
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  serviceName: {{ include "loki.ingesterFullname" . }}-headless
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.ingesterSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.ingester.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.ingesterSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.ingesterPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.ingester.terminationGracePeriodSeconds }}
+      containers:
+        - name: loki
+          image: {{ include "loki.ingesterImage" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=ingester
+            {{- with .Values.ingester.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
+          {{- with .Values.ingester.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ingester.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            - name: data
+              mountPath: /var/loki
+            {{- with .Values.ingester.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.ingester.resources | nindent 12 }}
+      {{- with .Values.ingester.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ingester.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ingester.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "loki.fullname" . }}
+        {{- with .Values.ingester.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- if not .Values.ingester.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+  {{- else }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.ingester.persistence.storageClass }}
+        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.ingester.persistence.size | quote }}
+  {{- end }}

--- a/charts/loki-distributed/templates/memcached-chunks/_helpers-memcached-chunks.tpl
+++ b/charts/loki-distributed/templates/memcached-chunks/_helpers-memcached-chunks.tpl
@@ -1,0 +1,32 @@
+{{/*
+memcached-chunks fullname
+*/}}
+{{- define "loki.memcachedChunksFullname" -}}
+{{ include "loki.fullname" . }}-memcached-chunks
+{{- end }}
+
+{{/*
+memcached-chunks fullname
+*/}}
+{{- define "loki.memcachedChunksLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: memcached-chunks
+{{- end }}
+
+{{/*
+memcached-chunks selector labels
+*/}}
+{{- define "loki.memcachedChunksSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: memcached-chunks
+{{- end }}
+
+{{/*
+memcached-chunks priority class name
+*/}}
+{{- define "loki.memcachedChunksPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.memcachedChunks.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/poddisruptionbudget-memcached-chunks.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.memcachedChunks.enabled (gt (int .Values.memcachedChunks.replicas) 1) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.memcachedChunksFullname" . }}
+  labels:
+    {{- include "loki.memcachedChunksLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedChunksSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-chunks/service-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/service-memcached-chunks.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.memcachedChunks.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.memcachedChunksFullname" . }}
+  labels:
+    {{- include "loki.memcachedChunksSelectorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 11211
+      targetPort: http
+      protocol: TCP
+    - name: http-metrics
+      port: 9150
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    {{- include "loki.memcachedChunksSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-chunks/servicemonitor-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/servicemonitor-memcached-chunks.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.memcachedChunks.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.memcachedChunksFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.memcachedChunksLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedChunksSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http-metrics
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.memcachedChunks.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "loki.memcachedChunksFullname" . }}
+  labels:
+    {{- include "loki.memcachedChunksLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.memcachedChunks.replicas }}
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  serviceName: {{ include "loki.memcachedChunksFullname" . }}
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedChunksSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if or .Values.loki.podAnnotations .Values.memcachedChunks.podAnnotations }}
+      annotations:
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.memcachedChunks.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels:
+        {{- include "loki.memcachedChunksSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.memcachedChunksPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.memcached.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.memcachedChunks.terminationGracePeriodSeconds }}
+      containers:
+        - name: memcached
+          image: {{ include "loki.memcachedImage" . }}
+          imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
+          {{- with .Values.memcachedChunks.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 11211
+              protocol: TCP
+          {{- with .Values.memcachedChunks.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.memcachedChunks.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.memcached.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            {{- toYaml .Values.memcachedChunks.resources | nindent 12 }}
+        {{- if .Values.memcachedExporter.enabled }}
+        - name: exporter
+          args:
+            - --memcached.address=localhost:11211
+            - --web.listen-address=0.0.0.0:9150
+          image: {{ include "loki.memcachedExporterImage" . }}
+          imagePullPolicy: {{ .Values.memcachedExporter.image.pullPolicy }}
+          ports:
+            - name: http-metrics
+              containerPort: 9150
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.memcachedExporter.resources | nindent 12 }}
+        {{- end }}
+      {{- with .Values.memcachedChunks.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.memcachedChunks.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.memcachedChunks.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/_helpers-memcached-frontend.tpl
+++ b/charts/loki-distributed/templates/memcached-frontend/_helpers-memcached-frontend.tpl
@@ -1,0 +1,32 @@
+{{/*
+memcached-frontend fullname
+*/}}
+{{- define "loki.memcachedFrontendFullname" -}}
+{{ include "loki.fullname" . }}-memcached-frontend
+{{- end }}
+
+{{/*
+memcached-frontend fullname
+*/}}
+{{- define "loki.memcachedFrontendLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: memcached-frontend
+{{- end }}
+
+{{/*
+memcached-frontend selector labels
+*/}}
+{{- define "loki.memcachedFrontendSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: memcached-frontend
+{{- end }}
+
+{{/*
+memcached-frontend priority class name
+*/}}
+{{- define "loki.memcachedFrontendPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.memcachedFrontend.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/poddisruptionbudget-memcached-frontend.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.memcachedFrontend.enabled (gt (int .Values.memcachedFrontend.replicas) 1) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.memcachedFrontendFullname" . }}
+  labels:
+    {{- include "loki.memcachedFrontendLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/service-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/service-memcached-frontend.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.memcachedFrontend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.memcachedFrontendFullname" . }}
+  labels:
+    {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 11211
+      targetPort: http
+      protocol: TCP
+    - name: http-metrics
+      port: 9150
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/servicemonitor-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/servicemonitor-memcached-frontend.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.memcachedFrontend.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.memcachedFrontendFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.memcachedFrontendLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedFrontendSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http-metrics
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-frontend/statefulset-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/statefulset-memcached-frontend.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.memcachedFrontend.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "loki.memcachedFrontendFullname" . }}
+  labels:
+    {{- include "loki.memcachedFrontendLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.memcachedFrontend.replicas }}
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  serviceName: {{ include "loki.memcachedFrontendFullname" . }}
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if or .Values.loki.podAnnotations .Values.memcachedFrontend.podAnnotations }}
+      annotations:
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.memcachedFrontend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels:
+        {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.memcachedFrontendPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.memcached.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.memcachedFrontend.terminationGracePeriodSeconds }}
+      containers:
+        - name: memcached
+          image: {{ include "loki.memcachedImage" . }}
+          imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
+          {{- with .Values.memcachedFrontend.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 11211
+              protocol: TCP
+          {{- with .Values.memcachedFrontend.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.memcachedFrontend.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.memcached.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            {{- toYaml .Values.memcachedFrontend.resources | nindent 12 }}
+        {{- if .Values.memcachedExporter.enabled }}
+        - name: exporter
+          args:
+            - --memcached.address=localhost:11211
+            - --web.listen-address=0.0.0.0:9150
+          image: {{ include "loki.memcachedExporterImage" . }}
+          imagePullPolicy: {{ .Values.memcachedExporter.image.pullPolicy }}
+          ports:
+            - name: http-metrics
+              containerPort: 9150
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.memcachedExporter.resources | nindent 12 }}
+        {{- end }}
+      {{- with .Values.memcachedFrontend.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.memcachedFrontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.memcachedFrontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-index-queries/_helpers-memcached-index-queries.tpl
+++ b/charts/loki-distributed/templates/memcached-index-queries/_helpers-memcached-index-queries.tpl
@@ -1,0 +1,32 @@
+{{/*
+memcached-index-queries fullname
+*/}}
+{{- define "loki.memcachedIndexQueriesFullname" -}}
+{{ include "loki.fullname" . }}-memcached-index-queries
+{{- end }}
+
+{{/*
+memcached-index-queries fullname
+*/}}
+{{- define "loki.memcachedIndexQueriesLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: memcached-index-queries
+{{- end }}
+
+{{/*
+memcached-index-queries selector labels
+*/}}
+{{- define "loki.memcachedIndexQueriesSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: memcached-index-queries
+{{- end }}
+
+{{/*
+memcached-index-queries priority class name
+*/}}
+{{- define "loki.memcachedIndexQueriesPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.memcachedIndexQueries.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/poddisruptionbudget-memcached-index-queries.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.memcachedIndexQueries.enabled (gt (int .Values.memcachedIndexQueries.replicas) 1) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.memcachedIndexQueriesFullname" . }}
+  labels:
+    {{- include "loki.memcachedIndexQueriesLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-index-queries/service-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/service-memcached-index-queries.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.memcachedIndexQueries.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.memcachedIndexQueriesFullname" . }}
+  labels:
+    {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 11211
+      targetPort: http
+      protocol: TCP
+    - name: http-metrics
+      port: 9150
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-index-queries/servicemonitor-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/servicemonitor-memcached-index-queries.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.memcachedIndexQueries.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.memcachedIndexQueriesFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.memcachedIndexQueriesLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedIndexQueriesSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http-metrics
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-index-queries/statefulset-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/statefulset-memcached-index-queries.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.memcachedIndexQueries.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "loki.memcachedIndexQueriesFullname" . }}
+  labels:
+    {{- include "loki.memcachedIndexQueriesLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.memcachedIndexQueries.replicas }}
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  serviceName: {{ include "loki.memcachedIndexQueriesFullname" . }}
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if or .Values.loki.podAnnotations .Values.memcachedIndexQueries.podAnnotations }}
+      annotations:
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.memcachedIndexQueries.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels:
+        {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.memcachedIndexQueriesPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.memcached.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.memcachedIndexQueries.terminationGracePeriodSeconds }}
+      containers:
+        - name: memcached
+          image: {{ include "loki.memcachedImage" . }}
+          imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
+          {{- with .Values.memcachedIndexQueries.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 11211
+              protocol: TCP
+          {{- with .Values.memcachedIndexQueries.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.memcachedIndexQueries.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.memcached.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            {{- toYaml .Values.memcachedIndexQueries.resources | nindent 12 }}
+        {{- if .Values.memcachedExporter.enabled }}
+        - name: exporter
+          args:
+            - --memcached.address=localhost:11211
+            - --web.listen-address=0.0.0.0:9150
+          image: {{ include "loki.memcachedExporterImage" . }}
+          imagePullPolicy: {{ .Values.memcachedExporter.image.pullPolicy }}
+          ports:
+            - name: http-metrics
+              containerPort: 9150
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.memcachedExporter.resources | nindent 12 }}
+        {{- end }}
+      {{- with .Values.memcachedIndexQueries.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.memcachedIndexQueries.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.memcachedIndexQueries.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-index-writes/_helpers-memcached-index-writes.tpl
+++ b/charts/loki-distributed/templates/memcached-index-writes/_helpers-memcached-index-writes.tpl
@@ -1,0 +1,32 @@
+{{/*
+memcached-index-writes fullname
+*/}}
+{{- define "loki.memcachedIndexWritesFullname" -}}
+{{ include "loki.fullname" . }}-memcached-index-writes
+{{- end }}
+
+{{/*
+memcached-index-writes fullname
+*/}}
+{{- define "loki.memcachedIndexWritesLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: memcached-index-writes
+{{- end }}
+
+{{/*
+memcached-index-writes selector labels
+*/}}
+{{- define "loki.memcachedIndexWritesSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: memcached-index-writes
+{{- end }}
+
+{{/*
+memcached-index-writes priority class name
+*/}}
+{{- define "loki.memcachedIndexWritesPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.memcachedIndexWrites.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/poddisruptionbudget-memcached-index-writes.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.memcachedIndexWrites.enabled (gt (int .Values.memcachedIndexWrites.replicas) 1) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.memcachedIndexWritesFullname" . }}
+  labels:
+    {{- include "loki.memcachedIndexWritesLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-index-writes/service-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/service-memcached-index-writes.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.memcachedIndexWrites.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.memcachedIndexWritesFullname" . }}
+  labels:
+    {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 11211
+      targetPort: http
+      protocol: TCP
+    - name: http-metrics
+      port: 9150
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-index-writes/servicemonitor-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/servicemonitor-memcached-index-writes.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.memcachedIndexWrites.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.memcachedIndexWritesFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.memcachedIndexWritesLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedIndexWritesSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http-metrics
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/memcached-index-writes/statefulset-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/statefulset-memcached-index-writes.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.memcachedIndexWrites.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "loki.memcachedIndexWritesFullname" . }}
+  labels:
+    {{- include "loki.memcachedIndexWritesLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.memcachedIndexWrites.replicas }}
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  serviceName: {{ include "loki.memcachedIndexWritesFullname" . }}
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if or .Values.loki.podAnnotations .Values.memcachedIndexWrites.podAnnotations }}
+      annotations:
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.memcachedIndexWrites.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels:
+        {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.memcachedIndexWritesPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.memcached.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.memcachedIndexWrites.terminationGracePeriodSeconds }}
+      containers:
+        - name: memcached
+          image: {{ include "loki.memcachedImage" . }}
+          imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
+          {{- with .Values.memcachedIndexWrites.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 11211
+              protocol: TCP
+          {{- with .Values.memcachedIndexWrites.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.memcachedIndexWrites.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.memcached.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            {{- toYaml .Values.memcachedIndexWrites.resources | nindent 12 }}
+        {{- if .Values.memcachedExporter.enabled }}
+        - name: exporter
+          args:
+            - --memcached.address=localhost:11211
+            - --web.listen-address=0.0.0.0:9150
+          image: {{ include "loki.memcachedExporterImage" . }}
+          imagePullPolicy: {{ .Values.memcachedExporter.image.pullPolicy }}
+          ports:
+            - name: http-metrics
+              containerPort: 9150
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.memcachedExporter.resources | nindent 12 }}
+        {{- end }}
+      {{- with .Values.memcachedIndexWrites.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.memcachedIndexWrites.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.memcachedIndexWrites.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/podsecuritypolicy.yaml
+++ b/charts/loki-distributed/templates/podsecuritypolicy.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "loki.fullname" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'persistentVolumeClaim'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
+{{- end }}

--- a/charts/loki-distributed/templates/prometheusrule.yaml
+++ b/charts/loki-distributed/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+{{- with .Values.prometheusRule }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "loki.fullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.labels" $ | nindent 4 }}
+  {{- with .labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    {{- toYaml .groups | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/querier/_helpers-querier.tpl
+++ b/charts/loki-distributed/templates/querier/_helpers-querier.tpl
@@ -1,0 +1,40 @@
+{{/*
+querier fullname
+*/}}
+{{- define "loki.querierFullname" -}}
+{{ include "loki.fullname" . }}-querier
+{{- end }}
+
+{{/*
+querier common labels
+*/}}
+{{- define "loki.querierLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: querier
+{{- end }}
+
+{{/*
+querier selector labels
+*/}}
+{{- define "loki.querierSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: querier
+{{- end }}
+
+{{/*
+querier image
+*/}}
+{{- define "loki.querierImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.querier.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}
+
+{{/*
+querier priority class name
+*/}}
+{{- define "loki.querierPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.querier.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
+++ b/charts/loki-distributed/templates/querier/poddisruptionbudget-querier.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.querier.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.querierFullname" . }}
+  labels:
+    {{- include "loki.querierLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.querierSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/loki-distributed/templates/querier/service-querier-headless.yaml
+++ b/charts/loki-distributed/templates/querier/service-querier-headless.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.querierFullname" . }}-headless
+  labels:
+    {{- include "loki.querierSelectorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.querierSelectorLabels" . | nindent 4 }}

--- a/charts/loki-distributed/templates/querier/service-querier.yaml
+++ b/charts/loki-distributed/templates/querier/service-querier.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.querierFullname" . }}
+  labels:
+    {{- include "loki.querierLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.querierSelectorLabels" . | nindent 4 }}

--- a/charts/loki-distributed/templates/querier/servicemonitor-querier.yaml
+++ b/charts/loki-distributed/templates/querier/servicemonitor-querier.yaml
@@ -1,0 +1,43 @@
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.querierFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.querierLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.querierSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/querier/statefulset-querier.yaml
+++ b/charts/loki-distributed/templates/querier/statefulset-querier.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "loki.querierFullname" . }}
+  labels:
+    {{- include "loki.querierLabels" . | nindent 4 }}
+    app.kubernetes.io/part-of: memberlist
+spec:
+  replicas: {{ .Values.querier.replicas }}
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+  serviceName: {{ include "loki.querierFullname" . }}-headless
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.querierSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.querier.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.querierSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.querierPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.querier.terminationGracePeriodSeconds }}
+      containers:
+        - name: loki
+          image: {{ include "loki.querierImage" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=querier
+            {{- with .Values.querier.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
+          {{- with .Values.querier.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.querier.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            - name: data
+              mountPath: /var/loki
+            {{- with .Values.querier.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.querier.resources | nindent 12 }}
+      {{- with .Values.querier.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.querier.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.querier.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "loki.fullname" . }}
+        {{- with .Values.querier.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- if not .Values.querier.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+  {{- else }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.querier.persistence.storageClass }}
+        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.querier.persistence.size | quote }}
+  {{- end }}

--- a/charts/loki-distributed/templates/query-frontend/_helpers-query-frontend.tpl
+++ b/charts/loki-distributed/templates/query-frontend/_helpers-query-frontend.tpl
@@ -1,0 +1,40 @@
+{{/*
+query-frontend fullname
+*/}}
+{{- define "loki.queryFrontendFullname" -}}
+{{ include "loki.fullname" . }}-query-frontend
+{{- end }}
+
+{{/*
+query-frontend common labels
+*/}}
+{{- define "loki.queryFrontendLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: query-frontend
+{{- end }}
+
+{{/*
+query-frontend selector labels
+*/}}
+{{- define "loki.queryFrontendSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: query-frontend
+{{- end }}
+
+{{/*
+query-frontend image
+*/}}
+{{- define "loki.queryFrontendImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.queryFrontend.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}
+
+{{/*
+query-frontend priority class name
+*/}}
+{{- define "loki.queryFrontendPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.queryFrontend.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/deployment-query-frontend.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki.queryFrontendFullname" . }}
+  labels:
+    {{- include "loki.queryFrontendLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.queryFrontend.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.queryFrontendSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.queryFrontend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.queryFrontendSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.queryFrontendPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.queryFrontend.terminationGracePeriodSeconds }}
+      containers:
+        - name: loki
+          image: {{ include "loki.queryFrontendImage" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=query-frontend
+            {{- with .Values.queryFrontend.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          {{- with .Values.queryFrontend.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.queryFrontend.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            {{- with .Values.queryFrontend.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.queryFrontend.resources | nindent 12 }}
+      {{- with .Values.queryFrontend.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.queryFrontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.queryFrontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "loki.fullname" . }}
+        {{- with .Values.queryFrontend.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
+++ b/charts/loki-distributed/templates/query-frontend/poddisruptionbudget-query-frontent.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.queryFrontend.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.queryFrontendFullname" . }}
+  labels:
+    {{- include "loki.queryFrontendLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.queryFrontendSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/loki-distributed/templates/query-frontend/service-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/service-query-frontend.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.queryFrontendFullname" . }}
+  labels:
+    {{- include "loki.queryFrontendLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.queryFrontendSelectorLabels" . | nindent 4 }}

--- a/charts/loki-distributed/templates/query-frontend/servicemonitor-query-frontend.yaml
+++ b/charts/loki-distributed/templates/query-frontend/servicemonitor-query-frontend.yaml
@@ -1,0 +1,43 @@
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.queryFrontendFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.queryFrontendLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.queryFrontendSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/role.yaml
+++ b/charts/loki-distributed/templates/role.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "loki.fullname" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+rules:
+  - apiGroups:      
+      - policy
+    resources:      
+      - podsecuritypolicies
+    verbs:          
+      - use
+    resourceNames:  
+      - {{ include "loki.fullname" . }}
+{{- end }}

--- a/charts/loki-distributed/templates/rolebinding.yaml
+++ b/charts/loki-distributed/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "loki.fullname" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "loki.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "loki.serviceAccountName" . }}
+{{- end }}

--- a/charts/loki-distributed/templates/ruler/_helpers-ruler.tpl
+++ b/charts/loki-distributed/templates/ruler/_helpers-ruler.tpl
@@ -1,0 +1,47 @@
+{{/*
+ruler fullname
+*/}}
+{{- define "loki.rulerFullname" -}}
+{{ include "loki.fullname" . }}-ruler
+{{- end }}
+
+{{/*
+ruler common labels
+*/}}
+{{- define "loki.rulerLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: ruler
+{{- end }}
+
+{{/*
+ruler selector labels
+*/}}
+{{- define "loki.rulerSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: ruler
+{{- end }}
+
+{{/*
+ruler image
+*/}}
+{{- define "loki.rulerImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.ruler.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}
+
+{{/*
+format rules dir
+*/}}
+{{- define "loki.rulerRulesDirName" -}}
+rules-{{ . | replace "_" "-" | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+ruler priority class name
+*/}}
+{{- define "loki.rulerPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.ruler.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/ruler/configmap-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/configmap-ruler.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.ruler.enabled }}
+{{- range $dir, $files := .Values.ruler.directories }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "loki.rulerFullname" $ }}-{{ include "loki.rulerRulesDirName" $dir }}
+  labels:
+    {{- include "loki.rulerLabels" $ | nindent 4 }}
+data:
+  {{- toYaml $files | nindent 2}}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/deployment-ruler.yaml
@@ -1,0 +1,115 @@
+{{- if .Values.ruler.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki.rulerFullname" . }}
+  labels:
+    {{- include "loki.rulerLabels" . | nindent 4 }}
+    app.kubernetes.io/part-of: memberlist
+spec:
+  replicas: {{ .Values.ruler.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.rulerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.ruler.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.rulerSelectorLabels" . | nindent 8 }}
+        app.kubernetes.io/part-of: memberlist
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.rulerPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.ruler.terminationGracePeriodSeconds }}
+      containers:
+        - name: loki
+          image: {{ include "loki.rulerImage" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=ruler
+            {{- with .Values.ruler.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          {{- with .Values.ruler.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ruler.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            - name: data
+              mountPath: /var/loki
+            - name: tmp
+              mountPath: /tmp/loki
+            {{- range $dir, $_ := .Values.ruler.directories }}
+            - name: {{ include "loki.rulerRulesDirName" $dir }}
+              mountPath: /etc/loki/rules/{{ $dir }}
+            {{- end }}
+            {{- with .Values.ruler.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.ruler.resources | nindent 12 }}
+      {{- with .Values.ruler.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ruler.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ruler.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "loki.fullname" . }}
+        {{- range $dir, $_ := .Values.ruler.directories }}
+        - name: {{ include "loki.rulerRulesDirName" $dir }}
+          configMap:
+            name: {{ include "loki.rulerFullname" $ }}-{{ include "loki.rulerRulesDirName" $dir }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          emptyDir: {}
+        {{- with .Values.ruler.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/poddisruptionbudget-ruler.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.ruler.enabled }}
+{{- if gt (int .Values.ruler.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.rulerFullname" . }}
+  labels:
+    {{- include "loki.rulerLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.rulerSelectorLabels" . | nindent 6 }}
+  maxUnavailable: 1
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/ruler/service-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/service-ruler.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ruler.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.rulerFullname" . }}
+  labels:
+    {{- include "loki.rulerSelectorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.rulerSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/loki-distributed/templates/ruler/servicemonitor-ruler.yaml
+++ b/charts/loki-distributed/templates/ruler/servicemonitor-ruler.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ruler.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.rulerFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.rulerLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.rulerSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/service-memberlist.yaml
+++ b/charts/loki-distributed/templates/service-memberlist.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.fullname" . }}-memberlist
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 7946
+      targetPort: http-memberlist
+      protocol: TCP
+  selector:
+    {{- include "loki.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/part-of: memberlist

--- a/charts/loki-distributed/templates/serviceaccount.yaml
+++ b/charts/loki-distributed/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "loki.serviceAccountName" . }}
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/table-manager/_helpers-table-manager.tpl
+++ b/charts/loki-distributed/templates/table-manager/_helpers-table-manager.tpl
@@ -1,0 +1,40 @@
+{{/*
+table-manager fullname
+*/}}
+{{- define "loki.tableManagerFullname" -}}
+{{ include "loki.fullname" . }}-table-manager
+{{- end }}
+
+{{/*
+table-manager common labels
+*/}}
+{{- define "loki.tableManagerLabels" -}}
+{{ include "loki.labels" . }}
+app.kubernetes.io/component: table-manager
+{{- end }}
+
+{{/*
+table-manager selector labels
+*/}}
+{{- define "loki.tableManagerSelectorLabels" -}}
+{{ include "loki.selectorLabels" . }}
+app.kubernetes.io/component: table-manager
+{{- end }}
+
+{{/*
+table-manager image
+*/}}
+{{- define "loki.tableManagerImage" -}}
+{{- $dict := dict "loki" .Values.loki.image "service" .Values.tableManager.image "global" .Values.global.image "defaultVersion" .Chart.AppVersion -}}
+{{- include "loki.lokiImage" $dict -}}
+{{- end }}
+
+{{/*
+table-manager priority class name
+*/}}
+{{- define "loki.tableManagerPriorityClassName" -}}
+{{- $pcn := coalesce .Values.global.priorityClassName .Values.tableManager.priorityClassName -}}
+{{- if $pcn }}
+priorityClassName: {{ $pcn }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/deployment-table-manager.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.tableManager.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "loki.tableManagerFullname" . }}
+  labels:
+    {{- include "loki.tableManagerLabels" . | nindent 4 }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: {{ .Values.loki.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "loki.tableManagerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.loki.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.tableManager.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "loki.tableManagerSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "loki.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "loki.tableManagerPriorityClassName" . | nindent 6 }}
+      securityContext:
+        {{- toYaml .Values.loki.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.tableManager.terminationGracePeriodSeconds }}
+      containers:
+        - name: loki
+          image: {{ include "loki.tableManagerImage" . }}
+          imagePullPolicy: {{ .Values.loki.image.pullPolicy }}
+          args:
+            - -config.file=/etc/loki/config/config.yaml
+            - -target=table-manager
+            {{- with .Values.tableManager.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          {{- with .Values.tableManager.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tableManager.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.loki.containerSecurityContext | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.loki.readinessProbe | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/config
+            {{- with .Values.tableManager.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.tableManager.resources | nindent 12 }}
+      {{- with .Values.tableManager.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tableManager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tableManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "loki.fullname" . }}
+        {{- with .Values.tableManager.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/table-manager/poddisruptionbudget-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/poddisruptionbudget-table-manager.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.tableManager.enabled }}
+{{- if gt (int .Values.tableManager.replicas) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "loki.fullname" . }}-tableManager
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tableManager
+spec:
+  selector:
+    matchLabels:
+      {{- include "loki.labels" . | nindent 6 }}
+      app.kubernetes.io/component: tableManager
+  maxUnavailable: 1
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/templates/table-manager/service-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/service-table-manager.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.tableManager.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loki.fullname" . }}-table-manager
+  labels:
+    {{- include "loki.labels" . | nindent 4 }}
+    app.kubernetes.io/component: table-manager
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9095
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    {{- include "loki.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: table-manager
+{{- end }}

--- a/charts/loki-distributed/templates/table-manager/servicemonitor-table-manager.yaml
+++ b/charts/loki-distributed/templates/table-manager/servicemonitor-table-manager.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.tableManager.enabled }}
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "loki.tableManagerFullname" $ }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "loki.tableManagerLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "loki.tableManagerSelectorLabels" $ | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- with .interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -1,0 +1,1037 @@
+global:
+  image:
+    # -- Overrides the Docker registry globally for all images
+    registry: null
+  # -- Overrides the priorityClassName for all pods
+  priorityClassName: null
+  # -- configures cluster domain ("cluster.local" by default)
+  clusterDomain: "cluster.local"
+  # -- configures DNS service name in kube-system
+  dnsService: "kube-dns"
+
+# -- Overrides the chart's name
+nameOverride: null
+
+# -- Overrides the chart's computed fullname
+fullnameOverride: null
+
+# -- Image pull secrets for Docker images
+imagePullSecrets: []
+
+loki:
+  # Configures the readiness probe for all of the Loki pods
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 1
+  image:
+    # -- The Docker registry
+    registry: docker.io
+    # -- Docker image repository
+    repository: grafana/loki
+    # -- Overrides the image tag whose default is the chart's appVersion
+    tag: null
+    # -- Docker image pull policy
+    pullPolicy: IfNotPresent
+  # -- Common annotations for all pods
+  podAnnotations: {}
+  # -- The number of old ReplicaSets to retain to allow rollback
+  revisionHistoryLimit: 10
+  # -- The SecurityContext for Loki pods
+  podSecurityContext:
+    fsGroup: 10001
+    runAsGroup: 10001
+    runAsNonRoot: true
+    runAsUser: 10001
+  # -- The SecurityContext for Loki containers
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
+  # -- Config file contents for Loki
+  # @default -- See values.yaml
+  config: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+
+    distributor:
+      ring:
+        kvstore:
+          store: memberlist
+
+    memberlist:
+      join_members:
+        - {{ include "loki.fullname" . }}-memberlist
+
+    ingester:
+      lifecycler:
+        ring:
+          kvstore:
+            store: memberlist
+          replication_factor: 1
+      chunk_idle_period: 30m
+      chunk_block_size: 262144
+      chunk_encoding: snappy
+      chunk_retain_period: 1m
+      max_transfer_retries: 0
+
+    limits_config:
+      enforce_metric_name: false
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+      max_cache_freshness_per_query: 10m
+
+    schema_config:
+      configs:
+        - from: 2020-09-07
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: loki_index_
+            period: 24h
+
+    storage_config:
+      boltdb_shipper:
+        shared_store: filesystem
+        active_index_directory: /var/loki/index
+        cache_location: /var/loki/cache
+        cache_ttl: 168h
+      filesystem:
+        directory: /var/loki/chunks
+
+    chunk_store_config:
+      max_look_back_period: 0s
+
+    table_manager:
+      retention_deletes_enabled: false
+      retention_period: 0s
+
+    query_range:
+      align_queries_with_step: true
+      max_retries: 5
+      split_queries_by_interval: 15m
+      cache_results: true
+      results_cache:
+        cache:
+          enable_fifocache: true
+          fifocache:
+            max_size_items: 1024
+            validity: 24h
+
+    frontend_worker:
+      frontend_address: {{ include "loki.queryFrontendFullname" . }}:9095
+
+    frontend:
+      log_queries_longer_than: 5s
+      compress_responses: true
+
+    compactor:
+      shared_store: filesystem
+
+    ruler:
+      storage:
+        type: local
+        local:
+          directory: /etc/loki/rules
+      ring:
+        kvstore:
+          store: memberlist
+      rule_path: /tmp/loki/scratch
+      alertmanager_url: https://alertmanager.xx
+      external_url: https://alertmanager.xx
+
+serviceAccount:
+  # -- Specifies whether a ServiceAccount should be created
+  create: true
+  # -- The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: null
+  # -- Image pull secrets for the service account
+  imagePullSecrets: []
+  # -- Annotations for the service account
+  annotations: {}
+
+# RBAC configuration
+rbac:
+  # -- If enabled, a PodSecurityPolicy is created
+  pspEnabled: false
+
+# ServiceMonitor configuration
+serviceMonitor:
+  # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
+  enabled: false
+  # -- Alternative namespace for ServiceMonitor resources
+  namespace: null
+  # -- Namespace selector for ServiceMonitor resources
+  namespaceSelector: {}
+  # -- ServiceMonitor annotations
+  annotations: {}
+  # -- Additional ServiceMonitor labels
+  labels: {}
+  # -- ServiceMonitor scrape interval
+  interval: null
+  # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
+  scrapeTimeout: null
+  # -- ServiceMonitor will use http by default, but you can pick https as well
+  scheme: http
+  # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
+  tlsConfig: null
+
+# Rules for the Prometheus Operator
+prometheusRule:
+  # -- If enabled, a PrometheusRule resource for Prometheus Operator is created
+  enabled: false
+  # -- Alternative namespace for the PrometheusRule resource
+  namespace: null
+  # -- PrometheusRule annotations
+  annotations: {}
+  # -- Additional PrometheusRule labels
+  labels: {}
+  # -- Contents of Prometheus rules file
+  groups: []
+  # - name: loki-rules
+  #   rules:
+  #     - record: job:loki_request_duration_seconds_bucket:sum_rate
+  #       expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job)
+  #     - record: job_route:loki_request_duration_seconds_bucket:sum_rate
+  #       expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job, route)
+  #     - record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
+  #       expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (node, namespace, pod, container)
+
+# Configuration for the ingester
+ingester:
+  # -- Number of replicas for the ingester
+  replicas: 1
+  image:
+    # -- The Docker registry for the ingester image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the ingester image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the ingester image. Overrides `loki.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for ingester pods
+  priorityClassName: null
+  # -- Annotations for ingester pods
+  podAnnotations: {}
+  # -- Additional CLI args for the ingester
+  extraArgs: []
+  # -- Environment variables to add to the ingester pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the ingester pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the ingester pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the ingester pods
+  extraVolumes: []
+  # -- Resource requests and limits for the ingester
+  resources: {}
+  # -- Grace period to allow the ingester to shutdown before it is killed. Especially for the ingestor,
+  # this must be increased. It must be long enough so ingesters can be gracefully shutdown flushing/transferring
+  # all data and to successfully leave the member ring on shutdown.
+  terminationGracePeriodSeconds: 300
+  # -- Affinity for ingester pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.ingesterSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.ingesterSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for ingester pods
+  nodeSelector: {}
+  # -- Tolerations for ingester pods
+  tolerations: []
+  persistence:
+    # -- Enable creating PVCs which is required when using boltdb-shipper
+    enabled: false
+    # -- Size of persistent disk
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
+
+# Configuration for the distributor
+distributor:
+  # -- Number of replicas for the distributor
+  replicas: 1
+  image:
+    # -- The Docker registry for the distributor image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the distributor image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the distributor image. Overrides `loki.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for distributor pods
+  priorityClassName: null
+  # -- Annotations for distributor pods
+  podAnnotations: {}
+  # -- Additional CLI args for the distributor
+  extraArgs: []
+  # -- Environment variables to add to the distributor pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the distributor pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the distributor pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the distributor pods
+  extraVolumes: []
+  # -- Resource requests and limits for the distributor
+  resources: {}
+  # -- Grace period to allow the distributor to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for distributor pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.distributorSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.distributorSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for distributor pods
+  nodeSelector: {}
+  # -- Tolerations for distributor pods
+  tolerations: []
+
+# Configuration for the querier
+querier:
+  # -- Number of replicas for the querier
+  replicas: 1
+  image:
+    # -- The Docker registry for the querier image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the querier image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the querier image. Overrides `loki.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for querier pods
+  priorityClassName: null
+  # -- Annotations for querier pods
+  podAnnotations: {}
+  # -- Additional CLI args for the querier
+  extraArgs: []
+  # -- Environment variables to add to the querier pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the querier pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the querier pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the querier pods
+  extraVolumes: []
+  # -- Resource requests and limits for the querier
+  resources: {}
+  # -- Grace period to allow the querier to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for querier pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.querierSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.querierSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for querier pods
+  nodeSelector: {}
+  # -- Tolerations for querier pods
+  tolerations: []
+  persistence:
+    # -- Enable creating PVCs for the querier cache
+    enabled: false
+    # -- Size of persistent disk
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
+
+# Configuration for the query-frontend
+queryFrontend:
+  # -- Number of replicas for the query-frontend
+  replicas: 1
+  image:
+    # -- The Docker registry for the query-frontend image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the query-frontend image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the query-frontend image. Overrides `loki.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for query-frontend pods
+  priorityClassName: null
+  # -- Annotations for query-frontend pods
+  podAnnotations: {}
+  # -- Additional CLI args for the query-frontend
+  extraArgs: []
+  # -- Environment variables to add to the query-frontend pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the query-frontend pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the query-frontend pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the query-frontend pods
+  extraVolumes: []
+  # -- Resource requests and limits for the query-frontend
+  resources: {}
+  # -- Grace period to allow the query-frontend to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for query-frontend pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.queryFrontendSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.queryFrontendSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for query-frontend pods
+  nodeSelector: {}
+  # -- Tolerations for query-frontend pods
+  tolerations: []
+
+# Configuration for the table-manager
+tableManager:
+  # -- Specifies whether the table-manager should be enabled
+  enabled: false
+  # -- Number of replicas for the table-manager
+  replicas: 1
+  image:
+    # -- The Docker registry for the table-manager image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the table-manager image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the table-manager image. Overrides `loki.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for table-manager pods
+  priorityClassName: null
+  # -- Annotations for table-manager pods
+  podAnnotations: {}
+  # -- Additional CLI args for the table-manager
+  extraArgs: []
+  # -- Environment variables to add to the table-manager pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the table-manager pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the table-manager pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the table-manager pods
+  extraVolumes: []
+  # -- Resource requests and limits for the table-manager
+  resources: {}
+  # -- Grace period to allow the table-manager to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for table-manager pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.tableManagerSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.tableManagerSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for table-manager pods
+  nodeSelector: {}
+  # -- Tolerations for table-manager pods
+  tolerations: []
+
+# Configuration for the gateway
+gateway:
+  # -- Number of replicas for the gateway
+  replicas: 1
+  image:
+    # -- The Docker registry for the gateway image
+    registry: docker.io
+    # -- The gateway image repository
+    repository: nginxinc/nginx-unprivileged
+    # -- The gateway image tag
+    tag: 1.19-alpine
+    # -- The gateway image pull policy
+    pullPolicy: IfNotPresent
+  # -- The name of the PriorityClass for gateway pods
+  priorityClassName: null
+  # -- Annotations for gateway pods
+  podAnnotations: {}
+  # -- Additional CLI args for the gateway
+  extraArgs: []
+  # -- Environment variables to add to the gateway pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the gateway pods
+  extraEnvFrom: []
+  # -- Volumes to add to the gateway pods
+  extraVolumes: []
+  # -- Volume mounts to add to the gateway pods
+  extraVolumeMounts: []
+  # -- The SecurityContext for gateway containers
+  podSecurityContext:
+    fsGroup: 101
+    runAsGroup: 101
+    runAsNonRoot: true
+    runAsUser: 101
+  # -- The SecurityContext for gateway containers
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
+  # -- Resource requests and limits for the gateway
+  resources: {}
+  # -- Grace period to allow the gateway to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.gatewaySelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.gatewaySelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for gateway pods
+  nodeSelector: {}
+  # -- Tolerations for gateway pods
+  tolerations: []
+  # Gateway service configuration
+  service:
+    # -- Port of the gateway service
+    port: 80
+    # -- Type of the gateway service
+    type: ClusterIP
+    # -- ClusterIP of the gateway service
+    clusterIP: null
+    # -- Node port if service type is NodePort
+    nodePort: null
+    # -- Load balancer IPO address if service type is LoadBalancer
+    loadBalancerIP: null
+    # -- Annotations for the gateway service
+    annotations: {}
+  # Gateway ingress configuration
+  ingress:
+    # -- Specifies whether an ingress for the gateway should be created
+    enabled: false
+    # -- Annotations for the gateway ingress
+    annotations: {}
+    # -- Hosts configuration for the gateway ingress
+    hosts:
+      - host: gateway.loki.example.com
+        paths:
+          - /
+    # -- TLS configuration for the gateway ingress
+    tls:
+      - secretName: loki-gateway-tls
+        hosts:
+          - gateway.loki.example.com
+  # Basic auth configuration
+  basicAuth:
+    # -- Enables basic authentication for the gateway
+    enabled: false
+    # -- The basic auth username for the gateway
+    username: null
+    # -- The basic auth password for the gateway
+    password: null
+    # -- Existing basic auth secret to use. Must contain '.htpasswd'
+    existingSecret: null
+  # Configures the readiness probe for the gateway
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+    initialDelaySeconds: 15
+    timeoutSeconds: 1
+  # -- Config file contents for Nginx. Passed through the `tpl` function to allow templating
+  # @default -- See values.yaml
+  nginxConfig: |
+    worker_processes  5;  ## Default: 1
+    error_log  /dev/stderr;
+    pid        /tmp/nginx.pid;
+    worker_rlimit_nofile 8192;
+
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+        '"$request" $body_bytes_sent "$http_referer" '
+        '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log   /dev/stderr  main;
+      sendfile     on;
+      tcp_nopush   on;
+      resolver {{ .Values.global.dnsService }}.kube-system.svc.{{ .Values.global.clusterDomain }};
+
+      server {
+        listen             8080;
+
+        {{- if .Values.gateway.basicAuth.enabled }}
+        auth_basic           "Loki";
+        auth_basic_user_file /etc/nginx/secrets/.htpasswd;
+        {{- end }}
+
+        location = / {
+          return 200 'OK';
+          auth_basic off;
+        }
+
+        location = /api/prom/push {
+          proxy_pass       http://{{ include "loki.distributorFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+        }
+
+        location = /api/prom/tail {
+          proxy_pass       http://{{ include "loki.querierFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+        }
+
+        location ~ /api/prom/.* {
+          proxy_pass       http://{{ include "loki.queryFrontendFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+        }
+
+        location = /loki/api/v1/push {
+          proxy_pass       http://{{ include "loki.distributorFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+        }
+
+        location = /loki/api/v1/tail {
+          proxy_pass       http://{{ include "loki.querierFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+        }
+
+        location ~ /loki/api/.* {
+          proxy_pass       http://{{ include "loki.queryFrontendFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+        }
+      }
+    }
+
+# Configuration for the compactor
+compactor:
+  # -- Specifies whether compactor should be enabled
+  enabled: false
+  image:
+    # -- The Docker registry for the compactor image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the compactor image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the compactor image. Overrides `loki.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for compactor pods
+  priorityClassName: null
+  # -- Annotations for compactor pods
+  podAnnotations: {}
+  # -- Additional CLI args for the compactor
+  extraArgs: []
+  # -- Environment variables to add to the compactor pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the compactor pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the compactor pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the compactor pods
+  extraVolumes: []
+  # -- Resource requests and limits for the compactor
+  resources: {}
+  # -- Grace period to allow the compactor to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Node selector for compactor pods
+  nodeSelector: {}
+  # -- Tolerations for compactor pods
+  tolerations: []
+  persistence:
+    # -- Enable creating PVCs for the compactor
+    enabled: false
+    # -- Size of persistent disk
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
+
+# Configuration for the ruler
+ruler:
+  # -- Specifies whether the ruler should be enabled
+  enabled: false
+  # -- Number of replicas for the ruler
+  replicas: 1
+  image:
+    # -- The Docker registry for the ruler image. Overrides `loki.image.registry`
+    registry: null
+    # -- Docker image repository for the ruler image. Overrides `loki.image.repository`
+    repository: null
+    # -- Docker image tag for the ruler image. Overrides `loki.image.tag`
+    tag: null
+  # -- The name of the PriorityClass for ruler pods
+  priorityClassName: null
+  # -- Annotations for ruler pods
+  podAnnotations: {}
+  # -- Additional CLI args for the ruler
+  extraArgs: []
+  # -- Environment variables to add to the ruler pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to the ruler pods
+  extraEnvFrom: []
+  # -- Volume mounts to add to the ruler pods
+  extraVolumeMounts: []
+  # -- Volumes to add to the ruler pods
+  extraVolumes: []
+  # -- Resource requests and limits for the ruler
+  resources: {}
+  # -- Grace period to allow the ruler to shutdown before it is killed
+  terminationGracePeriodSeconds: 300
+  # -- Affinity for ruler pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.rulerSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.rulerSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for ruler pods
+  nodeSelector: {}
+  # -- Tolerations for ruler pods
+  tolerations: []
+  persistence:
+    # -- Enable creating PVCs for the ruler
+    enabled: false
+    # -- Size of persistent disk
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
+  # -- Directories containing rules files
+  directories: {}
+    # tenant_foo:
+    #   rules1.txt: |
+    #     groups:
+    #       - name: should_fire
+    #         rules:
+    #           - alert: HighPercentageError
+    #             expr: |
+    #               sum(rate({app="foo", env="production"} |= "error" [5m])) by (job)
+    #                 /
+    #               sum(rate({app="foo", env="production"}[5m])) by (job)
+    #                 > 0.05
+    #             for: 10m
+    #             labels:
+    #               severity: warning
+    #             annotations:
+    #               summary: High error rate
+    #       - name: credentials_leak
+    #         rules:
+    #           - alert: http-credentials-leaked
+    #             annotations:
+    #               message: "{{ $labels.job }} is leaking http basic auth credentials."
+    #             expr: 'sum by (cluster, job, pod) (count_over_time({namespace="prod"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)'
+    #             for: 10m
+    #             labels:
+    #               severity: critical
+    #   rules2.txt: |
+    #     groups:
+    #       - name: example
+    #         rules:
+    #         - alert: HighThroughputLogStreams
+    #           expr: sum by(container) (rate({job=~"loki-dev/.*"}[1m])) > 1000
+    #           for: 2m
+    # tenant_bar:
+    #   rules1.txt: |
+    #     groups:
+    #       - name: should_fire
+    #         rules:
+    #           - alert: HighPercentageError
+    #             expr: |
+    #               sum(rate({app="foo", env="production"} |= "error" [5m])) by (job)
+    #                 /
+    #               sum(rate({app="foo", env="production"}[5m])) by (job)
+    #                 > 0.05
+    #             for: 10m
+    #             labels:
+    #               severity: warning
+    #             annotations:
+    #               summary: High error rate
+    #       - name: credentials_leak
+    #         rules:
+    #           - alert: http-credentials-leaked
+    #             annotations:
+    #               message: "{{ $labels.job }} is leaking http basic auth credentials."
+    #             expr: 'sum by (cluster, job, pod) (count_over_time({namespace="prod"} |~ "http(s?)://(\\w+):(\\w+)@" [5m]) > 0)'
+    #             for: 10m
+    #             labels:
+    #               severity: critical
+    #   rules2.txt: |
+    #     groups:
+    #       - name: example
+    #         rules:
+    #         - alert: HighThroughputLogStreams
+    #           expr: sum by(container) (rate({job=~"loki-dev/.*"}[1m])) > 1000
+    #           for: 2m
+
+memcached:
+  image:
+    # -- The Docker registry for the memcached
+    registry: docker.io
+    # -- Memcached Docker image repository
+    repository: memcached
+    # -- Memcached Docker image tag
+    tag: 1.6.7-alpine
+    # -- Memcached Docker image pull policy
+    pullPolicy: IfNotPresent
+  # -- The SecurityContext for memcached pods
+  podSecurityContext:
+    fsGroup: 11211
+    runAsGroup: 11211
+    runAsNonRoot: true
+    runAsUser: 11211
+  # -- The SecurityContext for memcached containers
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
+
+memcachedExporter:
+  # -- Specifies whether the Memcached Exporter should be enabled
+  enabled: false
+  image:
+    # -- The Docker registry for the Memcached Exporter
+    registry: docker.io
+    # -- Memcached Exporter Docker image repository
+    repository: prom/memcached-exporter
+    # -- Memcached Exporter Docker image tag
+    tag: v0.6.0
+    # -- Memcached Exporter Docker image pull policy
+    pullPolicy: IfNotPresent
+  # -- Memcached Exporter resource requests and limits
+  resources: {}
+
+memcachedChunks:
+  # -- Specifies whether the Memcached chunks cache should be enabled
+  enabled: false
+  # -- Number of replicas for memcached-chunks
+  replicas: 1
+  # -- The name of the PriorityClass for memcached-chunks pods
+  priorityClassName: null
+  # -- Annotations for memcached-chunks pods
+  podAnnotations: {}
+  # -- Additional CLI args for memcached-chunks
+  extraArgs: []
+  # -- Environment variables to add to memcached-chunks pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to memcached-chunks pods
+  extraEnvFrom: []
+  # -- Resource requests and limits for memcached-chunks
+  resources: {}
+  # -- Grace period to allow memcached-chunks to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for memcached-chunks pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.memcachedChunksSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.memcachedChunksSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for memcached-chunks pods
+  nodeSelector: {}
+  # -- Tolerations for memcached-chunks pods
+  tolerations: []
+
+memcachedFrontend:
+  # -- Specifies whether the Memcached frontend cache should be enabled
+  enabled: false
+  # -- Number of replicas for memcached-frontend
+  replicas: 1
+  # -- The name of the PriorityClass for memcached-frontend pods
+  priorityClassName: null
+  # -- Annotations for memcached-frontend pods
+  podAnnotations: {}
+  # -- Additional CLI args for memcached-frontend
+  extraArgs: []
+  # -- Environment variables to add to memcached-frontend pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to memcached-frontend pods
+  extraEnvFrom: []
+  # -- Resource requests and limits for memcached-frontend
+  resources: {}
+  # -- Grace period to allow memcached-frontend to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for memcached-frontend pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.memcachedFrontendSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for memcached-frontend pods
+  nodeSelector: {}
+  # -- Tolerations for memcached-frontend pods
+  tolerations: []
+
+memcachedIndexQueries:
+  # -- Specifies whether the Memcached index queries cache should be enabled
+  enabled: false
+  # -- Number of replicas for memcached-index-queries
+  replicas: 1
+  # -- The name of the PriorityClass for memcached-index-queries pods
+  priorityClassName: null
+  # -- Annotations for memcached-index-queries pods
+  podAnnotations: {}
+  # -- Additional CLI args for memcached-index-queries
+  extraArgs: []
+  # -- Environment variables to add to memcached-index-queries pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to memcached-index-queries pods
+  extraEnvFrom: []
+  # -- Resource requests and limits for memcached-index-queries
+  resources: {}
+  # -- Grace period to allow memcached-index-queries to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for memcached-index-queries pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.memcachedIndexQueriesSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for memcached-index-queries pods
+  nodeSelector: {}
+  # -- Tolerations for memcached-index-queries pods
+  tolerations: []
+
+memcachedIndexWrites:
+  # -- Specifies whether the Memcached index writes cache should be enabled
+  enabled: false
+  # -- Number of replicas for memcached-index-writes
+  replicas: 1
+  # -- The name of the PriorityClass for memcached-index-writes pods
+  priorityClassName: null
+  # -- Annotations for memcached-index-writes pods
+  podAnnotations: {}
+  # -- Additional CLI args for memcached-index-writes
+  extraArgs: []
+  # -- Environment variables to add to memcached-index-writes pods
+  extraEnv: []
+  # -- Environment variables from secrets or configmaps to add to memcached-index-writes pods
+  extraEnvFrom: []
+  # -- Resource requests and limits for memcached-index-writes
+  resources: {}
+  # -- Grace period to allow memcached-index-writes to shutdown before it is killed
+  terminationGracePeriodSeconds: 30
+  # -- Affinity for memcached-index-writes pods. Passed through `tpl` and, thus, to be configured as string
+  # @default -- Hard node and soft zone anti-affinity
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 10 }}
+          topologyKey: kubernetes.io/hostname
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                {{- include "loki.memcachedIndexWritesSelectorLabels" . | nindent 12 }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+  # -- Node selector for memcached-index-writes pods
+  nodeSelector: {}
+  # -- Tolerations for memcached-index-writes pods
+  tolerations: []

--- a/config/loki-grafana-cassandra-promtail-setup.md
+++ b/config/loki-grafana-cassandra-promtail-setup.md
@@ -15,23 +15,23 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 Then install cassandra in the cluster:
 ```bash
-helm --namespace cassandra upgrade --atomic --create-namespace --install cassandra bitnami/cassandra --values cassandra/values.yaml
+helm --namespace mla upgrade --atomic --create-namespace --install cassandra bitnami/cassandra --values cassandra/values.yaml
 ```
 
 
 ## Install Grafana in a cluster
 ```bash
-helm --namespace grafana upgrade --atomic --create-namespace --install grafana grafana/grafana --values grafana/values.yaml
+helm --namespace mla upgrade --atomic --create-namespace --install grafana grafana/grafana --values grafana/values.yaml
 ```
 
 ## Install Loki
 ```bash
-helm --namespace loki upgrade --atomic --create-namespace --install loki grafana/loki-distributed --values loki/values.yaml
+helm --namespace mla upgrade --atomic --create-namespace --install loki-distributed grafana/loki-distributed --values loki/values.yaml
 ```
 
 ## Install Promtail
 ```bash
-helm --namespace promtail upgrade --atomic --create-namespace --install promail grafana/promtail --values promtail/values.yaml
+helm --namespace promtail upgrade --atomic --create-namespace --install promtail grafana/promtail --values promtail/values.yaml
 ```
 
 ## Add Loki to Grafana

--- a/config/loki/values.yaml
+++ b/config/loki/values.yaml
@@ -98,3 +98,66 @@ memcachedIndexQueries:
 
 memcachedIndexWrites:
   enabled: true
+
+gateway:
+  basicAuth:
+    enabled: true
+    username: loki
+    password: password
+  nginxConfig: |
+    worker_processes  5;  ## Default: 1
+    error_log  /dev/stderr;
+    pid        /tmp/nginx.pid;
+    worker_rlimit_nofile 8192;
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+        '"$request" $body_bytes_sent "$http_referer" '
+        '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log   /dev/stderr  main;
+      sendfile     on;
+      tcp_nopush   on;
+      resolver {{ .Values.global.dnsService }}.kube-system.svc.{{ .Values.global.clusterDomain }};
+      server {
+        proxy_set_header     X-Scope-OrgID 1;
+        listen             8080;
+        {{- if .Values.gateway.basicAuth.enabled }}
+        auth_basic           {{ .Values.gateway.basicAuth.username }};
+        auth_basic_user_file /etc/nginx/secrets/.htpasswd;
+        {{- end }}
+        location = / {
+          return 200 'OK';
+          auth_basic off;
+        }
+        location = /api/prom/push {
+          proxy_pass       http://{{ include "loki.distributorFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+        }
+        location = /api/prom/tail {
+          proxy_pass       http://{{ include "loki.querierFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+        }
+        location ~ /api/prom/.* {
+          proxy_pass       http://{{ include "loki.queryFrontendFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+        }
+        location = /loki/api/v1/push {
+          proxy_pass       http://{{ include "loki.distributorFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+        }
+        location = /loki/api/v1/tail {
+          proxy_pass       http://{{ include "loki.querierFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+        }
+        location ~ /loki/api/.* {
+          proxy_pass       http://{{ include "loki.queryFrontendFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
+        }
+      }
+    }

--- a/config/loki/values.yaml
+++ b/config/loki/values.yaml
@@ -39,7 +39,7 @@ loki:
           store: cassandra
     storage_config:
       cassandra:
-        addresses: cassandra.cassandra.svc.cluster.local
+        addresses: cassandra.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}
         auth: true
         username: cassandra
         password: cassandra
@@ -98,66 +98,3 @@ memcachedIndexQueries:
 
 memcachedIndexWrites:
   enabled: true
-
-gateway:
-  basicAuth:
-    enabled: true
-    username: loki
-    password: password
-  nginxConfig: |
-    worker_processes  5;  ## Default: 1
-    error_log  /dev/stderr;
-    pid        /tmp/nginx.pid;
-    worker_rlimit_nofile 8192;
-    events {
-      worker_connections  4096;  ## Default: 1024
-    }
-    http {
-      client_body_temp_path /tmp/client_temp;
-      proxy_temp_path       /tmp/proxy_temp_path;
-      fastcgi_temp_path     /tmp/fastcgi_temp;
-      uwsgi_temp_path       /tmp/uwsgi_temp;
-      scgi_temp_path        /tmp/scgi_temp;
-      default_type application/octet-stream;
-      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
-        '"$request" $body_bytes_sent "$http_referer" '
-        '"$http_user_agent" "$http_x_forwarded_for"';
-      access_log   /dev/stderr  main;
-      sendfile     on;
-      tcp_nopush   on;
-      resolver {{ .Values.global.dnsService }}.kube-system.svc.{{ .Values.global.clusterDomain }};
-      server {
-        proxy_set_header     X-Scope-OrgID 1;
-        listen             8080;
-        {{- if .Values.gateway.basicAuth.enabled }}
-        auth_basic           {{ .Values.gateway.basicAuth.username }};
-        auth_basic_user_file /etc/nginx/secrets/.htpasswd;
-        {{- end }}
-        location = / {
-          return 200 'OK';
-          auth_basic off;
-        }
-        location = /api/prom/push {
-          proxy_pass       http://{{ include "loki.distributorFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
-        }
-        location = /api/prom/tail {
-          proxy_pass       http://{{ include "loki.querierFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
-          proxy_set_header Upgrade $http_upgrade;
-          proxy_set_header Connection "upgrade";
-        }
-        location ~ /api/prom/.* {
-          proxy_pass       http://{{ include "loki.queryFrontendFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
-        }
-        location = /loki/api/v1/push {
-          proxy_pass       http://{{ include "loki.distributorFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
-        }
-        location = /loki/api/v1/tail {
-          proxy_pass       http://{{ include "loki.querierFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
-          proxy_set_header Upgrade $http_upgrade;
-          proxy_set_header Connection "upgrade";
-        }
-        location ~ /loki/api/.* {
-          proxy_pass       http://{{ include "loki.queryFrontendFullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:3100$request_uri;
-        }
-      }
-    }

--- a/config/promtail/values.yaml
+++ b/config/promtail/values.yaml
@@ -1,2 +1,2 @@
 config:
-  lokiAddress: http://loki:password@loki-loki-distributed-gateway.loki.svc/loki/api/v1/push
+  lokiAddress: http://loki:password@loki-distributed-gateway.loki.svc/loki/api/v1/push

--- a/deploy-seed.sh
+++ b/deploy-seed.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# MLA components namespace
+MLA_NS=mla
+
+echo "Adding Helm repos"
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo add bitnami https://charts.bitnami.com/bitnami
+
+echo ""
+echo "Installing Cassandra"
+helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install cassandra bitnami/cassandra --values config/cassandra/values.yaml
+
+echo ""
+echo "Installing Loki"
+helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install loki-distributed charts/loki-distributed --values config/loki/values.yaml
+
+echo ""
+echo "Installing Grafana"
+helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install grafana grafana/grafana --values config/grafana/values.yaml
+
+
+echo ""
+echo "Installing a Gateway for cluster-xyz"
+helm --namespace cluster-xyz upgrade --atomic --create-namespace --install mla-gw charts/gateway --set mla.namespace=${MLA_NS}
+
+echo ""
+echo "Installing Promtail"
+helm --namespace promtail upgrade --atomic --create-namespace --install promtail grafana/promtail --set config.lokiAddress=http://mla-gateway.cluster-xyz.svc.cluster.local/loki/api/v1/push


### PR DESCRIPTION
- added a copy of loki-distributed Helm chart, but without Gateway
- added a Gateway Helm chart (temporary, will be driven by code later)
- put all MLA components into a single namespace
- whole stack can be installed with `./deploy-seed.sh`
- promtail still part of `./deploy-seed.sh` but will be moved to a new `./deploy-user-cluster.sh` soon

```
k get pods -A                                                                                                                      ✔  default ⎈ 
NAMESPACE              NAME                                               READY   STATUS    RESTARTS   AGE
cluster-xyz            mla-gateway-cf9d97c57-tm82t                        1/1     Running   0          18m
mla                    cassandra-0                                        1/1     Running   0          24m
mla                    cassandra-1                                        1/1     Running   0          23m
mla                    cassandra-2                                        1/1     Running   0          21m
mla                    grafana-748799d97d-s8snw                           1/1     Running   0          18m
mla                    loki-distributed-distributor-775f685cc6-fkz98      1/1     Running   0          20m
mla                    loki-distributed-ingester-0                        1/1     Running   0          20m
mla                    loki-distributed-memcached-chunks-0                2/2     Running   0          20m
mla                    loki-distributed-memcached-frontend-0              2/2     Running   0          20m
mla                    loki-distributed-memcached-index-queries-0         2/2     Running   0          20m
mla                    loki-distributed-memcached-index-writes-0          2/2     Running   0          20m
mla                    loki-distributed-querier-0                         1/1     Running   0          20m
mla                    loki-distributed-query-frontend-6cc54c4c8c-kp877   1/1     Running   0          20m
mla                    loki-distributed-table-manager-84956ff978-k5t46    1/1     Running   0          20m
promtail               promtail-4r5sk                                     1/1     Running   0          11m

```