### PR TITLE
Add Cortex configuration to MLA stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,15 @@ After all pods are ready, you can add Loki as a datasource in Grafana.
 Go to your Grafana page, login with username `admin`, password `admin`.
 Then add Loki as a datasource.
 The URL is `http://mla-gateway.cluster-xyz.svc.cluster.local`. Click `Save & Test`.
+For Prometheus, the URL is `http://mla-gateway.cluster-xyz.svc.cluster.local/api/prom`.
 
-And do the same for Prometheus with URL
-* `http://thanos-query-frontend.mla.svc.cluster.local:9090` for SuperUser
-* `http://mla-gateway.cluster-xyz.svc.cluster.local` for tenant user
+### Check Alertmanager UI
+Currently, to be able to see the Alertmanager UI, we need to create a alertmanager configuration first:
+```bash
+./create-alert-config.sh  a24c848bd4d914cdcbbc7c860f4fe9d4-1893886320.eu-central-1.elb.amazonaws.com tenant-2
+```
+The first argument is the address of **mla-gateway-alert**, and the second argument is used for creating the receiver 
+in Alertmanger configuration.
+
+After this, you should be able to see the alertmanager UI at:
+`http://<mla-gateway-alert adress>/api/prom/alertmanager`.

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ The first argument is the address of **mla-gateway-alert**, and the second argum
 in Alertmanger configuration.
 
 After this, you should be able to see the alertmanager UI at:
-`http://<mla-gateway-alert adress>/api/prom/alertmanager`.
+`http://<mla-gateway-alert address>/api/prom/alertmanager`.

--- a/charts/gateway/templates/gateway.yaml
+++ b/charts/gateway/templates/gateway.yaml
@@ -24,7 +24,7 @@ data:
       default_type application/octet-stream;
       log_format   main '$remote_addr - $remote_user [$time_local]  $status '
         '"$request" $body_bytes_sent "$http_referer" '
-        '"$http_user_agent" "$http_x_forwarded_for"';
+        '"$http_user_agent" "$http_x_forwarded_for" $http_x_scope_orgid';
       access_log   /dev/stderr  main;
       sendfile     on;
       tcp_nopush   on;
@@ -34,19 +34,15 @@ data:
       server {
         listen             8080;
         proxy_set_header X-Scope-OrgID {{ .Values.mla.tenantID }};
-        proxy_set_header THANOS-TENANT {{ .Values.mla.tenantID }};
 
-
-        location = /api/prom/push {
-          proxy_pass       http://loki-distributed-distributor.{{ .Values.mla.namespace }}.svc.cluster.local:3100$request_uri;
-        }
-
-        location = /api/v1/receive {
-          proxy_pass       http://thanos-receive.{{ .Values.mla.namespace }}.svc.cluster.local:19291$request_uri;
-        }
-
+        # Loki Config
         location = /loki/api/v1/push {
           proxy_pass       http://loki-distributed-distributor.{{ .Values.mla.namespace }}.svc.cluster.local:3100$request_uri;
+        }
+
+        # Cortex Config
+        location = /api/v1/push {
+          proxy_pass      http://cortex-distributor.{{ .Values.mla.namespace }}.svc.cluster.local:8080$request_uri;
         }
       }
 
@@ -67,10 +63,6 @@ data:
         #   proxy_set_header Connection "upgrade";
         # }
 
-        location ~ /api/prom/.* {
-          proxy_pass       http://loki-distributed-query-frontend.{{ .Values.mla.namespace }}.svc.cluster.local:3100$request_uri;
-        }
-
         # location = /loki/api/v1/tail {
         #   proxy_pass       http://loki-distributed-querier.{{ .Values.mla.namespace }}.svc.cluster.local:3100$request_uri;
         #   proxy_set_header Upgrade $http_upgrade;
@@ -81,9 +73,26 @@ data:
           proxy_pass       http://loki-distributed-query-frontend.{{ .Values.mla.namespace }}.svc.cluster.local:3100$request_uri;
         }
 
-        location ~ /api/v1/.* {
-          set $args $args&tenant_id={{ .Values.mla.tenantID }};
-          proxy_pass       http://prom-label-proxy.{{ .Values.mla.namespace }}.svc.cluster.local$uri$is_args$args;
+        # Cortex Config
+        location ~ /api/prom/.* {
+          proxy_pass       http://cortex-query-frontend.{{ .Values.mla.namespace }}.svc.cluster.local:8080$request_uri;
+        }
+      }
+
+      # public read and write path - used for alertmanager only
+      server {
+        listen             8082;
+        proxy_set_header   X-Scope-OrgID {{ .Values.mla.tenantID }};
+
+        # Alertmanager Config
+        location ~ /api/prom/alertmanager.* {
+          proxy_pass      http://cortex-alertmanager.{{ .Values.mla.namespace }}.svc.cluster.local:8080$request_uri;
+        }
+        location ~ /api/v1/alerts {
+          proxy_pass      http://cortex-alertmanager.{{ .Values.mla.namespace }}.svc.cluster.local:8080$request_uri;
+        }
+        location ~ /multitenant_alertmanager/status {
+          proxy_pass      http://cortex-alertmanager.{{ .Values.mla.namespace }}.svc.cluster.local:8080$request_uri;
         }
       }
     }
@@ -99,6 +108,23 @@ spec:
     - name: http-ext
       port: 80
       targetPort: http-ext
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: mla
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: cluster-xyz
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mla-gateway-alert
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http-alert
+      port: 80
+      targetPort: http-alert
       protocol: TCP
   selector:
     app.kubernetes.io/name: mla
@@ -166,6 +192,9 @@ spec:
               protocol: TCP
             - name: http-int
               containerPort: 8081
+              protocol: TCP
+            - name: http-alert
+              containerPort: 8082
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/config/consul/values.yaml
+++ b/config/consul/values.yaml
@@ -1,0 +1,2 @@
+server:
+  replicas: 1

--- a/config/cortex/values.yaml
+++ b/config/cortex/values.yaml
@@ -1,0 +1,62 @@
+ingress:
+  enabled: false
+
+distributor:
+  replicas: 1
+
+ingester:
+  replicas: 2
+
+querier:
+  replicas: 1
+
+query_frontend:
+  replicas: 1
+
+nginx:
+  enabled: false
+
+alertmanager:
+  extraVolumeMounts:
+    - mountPath: /tmp
+      name: storage
+
+config:
+  auth_enabled: true
+  ingester:
+    lifecycler:
+      ring:
+        kvstore:
+          store: consul
+          prefix: 'collectors/'
+          consul:
+            host: 'consul-consul-server:8500'
+  ruler:
+    enable_api: true
+    storage:
+      type: s3
+      s3:
+        bucketnames: "cortex"
+        endpoint: "minio.mla.svc.cluster.local:9000"
+        access_key_id: "minio"
+        secret_access_key: "minio123"
+        s3forcepathstyle: true
+        insecure: true
+  alertmanager:
+    enable_api: true
+    storage:
+      type: s3
+      s3:
+        bucketnames: "cortex"
+        endpoint: "minio.mla.svc.cluster.local:9000"
+        access_key_id: "minio"
+        secret_access_key: "minio123"
+        s3forcepathstyle: true
+        insecure: true
+  storage:
+    cassandra:
+      addresses: cassandra.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+      keyspace: cortex
+      auth: true
+      username: cassandra
+      password: cassandra

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -1,0 +1,8 @@
+accessKey: "minio"
+secretKey: "minio123"
+replicas: 1
+defaultBucket:
+  enabled: true
+  name: cortex
+  ## This gives the Alertmanger permission to read and write configurations to minio
+  policy: public

--- a/create-alert-config.sh
+++ b/create-alert-config.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+GW_ADDRESS=mla-gateway-ext.cluster-xyz.svc.cluster.local/api/v1/alerts
+
+if [ -n "$1" ]; then
+  GW_ADDRESS=$1
+fi
+
+echo "Using Gateway: ${GW_ADDRESS}"
+
+# default tenant name
+TENANT_NAME=xyz
+
+if [ -n "$2" ]; then
+  TENANT_NAME=$2
+fi
+
+curl -XPOST http://${GW_ADDRESS}/api/v1/alerts -d "
+alertmanager_config: |
+  global:
+    smtp_smarthost: 'localhost:25'
+    smtp_from: '${TENANT_NAME}@example.org'
+  route:
+    receiver: ${TENANT_NAME}
+  receivers:
+    - name: ${TENANT_NAME}
+      email_configs:
+      - to: '${TENANT_NAME}@example.org'"

--- a/deploy-seed.sh
+++ b/deploy-seed.sh
@@ -6,24 +6,31 @@ MLA_NS=mla
 echo "Adding Helm repos"
 helm repo add grafana https://grafana.github.io/helm-charts
 helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add cortex-helm https://cortexproject.github.io/cortex-helm-chart
+helm repo add hashicorp https://helm.releases.hashicorp.com
+helm repo add minio https://helm.min.io
+
 helm repo update
+
+echo ""
+echo "Installing Minio"
+helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install minio minio/minio --version 8.0.10 --values config/minio/values.yaml
 
 echo ""
 echo "Installing Cassandra"
 helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install cassandra bitnami/cassandra --version 7.3.2 --values config/cassandra/values.yaml
 
-echo ""
-echo "Installing Loki"
-helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install loki-distributed charts/loki-distributed --values config/loki/values.yaml
+echo "Installing Consul"
+helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install consul hashicorp/consul  --version 0.30.0 --values config/consul/values.yaml
 
 echo ""
 echo "Installing Grafana"
 helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install grafana grafana/grafana --version 6.4.2 --values config/grafana/values.yaml
 
 echo ""
-echo "Installing PromLabelProxy"
-helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install prom-label-proxy charts/prom-label-proxy
+echo "Installing Cortex"
+helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install cortex cortex-helm/cortex --version 0.3.0 --values config/cortex/values.yaml
 
 echo ""
-echo "Installing Thanos"
-helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install thanos bitnami/thanos --version 3.10.1 --values config/thanos/values.yaml
+echo "Installing Loki"
+helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install loki-distributed charts/loki-distributed --values config/loki/values.yaml

--- a/deploy-user-cluster.sh
+++ b/deploy-user-cluster.sh
@@ -23,4 +23,4 @@ echo ""
 echo "Installing Prometheus"
 helm --namespace monitoring upgrade --atomic --create-namespace --install prometheus prometheus-community/prometheus --version 13.3.2 \
     --set alertmanager.enabled=false \
-    --set server.remoteWrite[0].url=http://${GW_ADDRESS}/api/v1/receive
+    --set server.remoteWrite[0].url=http://${GW_ADDRESS}/api/v1/push


### PR DESCRIPTION
This PR replaces Thanos with Cortex in MLA stack in order to provide multi-tenancy Alertmanager support.
To do that, it introduces few other components:
- Concul: for communications between cortex components.
- Minio: for storing Alertmanger configurations.

For Alertmanger, there is a public gateway service is added (mla-gateway-alert) to see the Alertmanger UI and upload alertmanger configurations.

Also, currently, for seeing the Alertmanger UI, we should create the Alertmanger configuration first. In the future, we can define a fallback Alertmanger configuration (see: https://cortexmetrics.io/docs/configuration/configuration-file/#alertmanager_config for more details), which will be used if no Alertmanger configuration is specified. In current PoC, we don't use the fallback configuration because in that way the same configuration will be used for all tenants, and we can not see if multi-tenancy is working.

For now, Memcached is disabled in Cortex, this is because Loki is also using it, and we don't want to deploy memchched stack twice, and we should find a way of sharing Memcached between Cortex and Loki.