### PR TITLE
Mount the storage(empty-dir) for cortex ruler

### DIFF
--- a/config/cortex/values.yaml
+++ b/config/cortex/values.yaml
@@ -20,6 +20,9 @@ ruler:
         secretKeyRef:
           name: minio
           key: secretkey
+  extraVolumeMounts:
+    - mountPath: /rules
+      name: storage
 
 compactor:
   replicas: 1


### PR DESCRIPTION
This PR mounts the storage (empty dir) also for ruler (like what we did for alertmanager, we mount `/tmp` for it).
This is needed, otherwise, the ruler will have some errors like `make /rules, read-only filesystem` in the log.
However, every rules/rule groups are stored in minio.