### PR TITLE
cortex chart needs longer time

### DIFF
--- a/hack/deploy-seed.sh
+++ b/hack/deploy-seed.sh
@@ -18,7 +18,7 @@ helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install grafana
 echo ""
 echo "Installing Cortex"
 helm dependency update charts/cortex  # need that to store memcached in charts directory
-helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install cortex charts/cortex --values config/cortex/values.yaml
+helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install cortex charts/cortex --values config/cortex/values.yaml --timeout 10m
 
 echo ""
 echo "Installing Loki"


### PR DESCRIPTION
If we run out of the node capacity to schedule all the new pods needed by cortex, cluster-autoscaler adds new node which can easily take 3-4 minutes. So we need cortext chart timeout to be 10m.