### PR TITLE
Minor fixes

### DIFF
--- a/config/cortex/values.yaml
+++ b/config/cortex/values.yaml
@@ -96,7 +96,7 @@ nginx:
   enabled: false
 
 alertmanager:
-  replicas: 2
+  replicas: 1
   statefulSet:
     enabled: true
   persistentVolume:

--- a/config/loki/values.yaml
+++ b/config/loki/values.yaml
@@ -145,6 +145,8 @@ ruler:
   extraArgs:
     - -ruler.storage.s3.access-key-id=$(accesskey)
     - -ruler.storage.s3.secret-access-key=$(secretkey)
+    - -s3.access-key-id=$(accesskey)
+    - -s3.secret-access-key=$(secretkey)
   extraEnvFrom:
     - secretRef:
         name: minio


### PR DESCRIPTION
This PR includes the following minor fixes:
- Rescale alertmanager replica to 1, so we can make sure that we always interact with the same alertmanager. This also fixes the issue that after refreshing alertmanager UI, sometimes you would lose all alerts because you may interact with another alertmanager instance.
- Add s3 key id and access key for Loki ruler, because it needs to download index from s3.