### PR TITLE
master/seed mla stack requires port numberts for scraping

### DIFF
--- a/charts/cortex/values.yaml
+++ b/charts/cortex/values.yaml
@@ -204,7 +204,7 @@ alertmanager:
   ## Pod Annotations
   podAnnotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: 'http-metrics'
+    prometheus.io/port: '8080'
 
   nodeSelector: {}
   affinity: {}
@@ -360,7 +360,7 @@ distributor:
   ## Pod Annotations
   podAnnotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: 'http-metrics'
+    prometheus.io/port: '8080'
 
   nodeSelector: {}
   affinity:
@@ -450,7 +450,7 @@ ingester:
   ## Pod Annotations
   podAnnotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: 'http-metrics'
+    prometheus.io/port: '8080'
 
   nodeSelector: {}
   affinity:
@@ -580,7 +580,7 @@ ruler:
   ## Pod Annotations
   podAnnotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: 'http-metrics'
+    prometheus.io/port: '8080'
 
   nodeSelector: {}
   affinity: {}
@@ -671,7 +671,7 @@ querier:
   ## Pod Annotations
   podAnnotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: 'http-metrics'
+    prometheus.io/port: '8080'
 
   nodeSelector: {}
   affinity:
@@ -755,7 +755,7 @@ query_frontend:
   ## Pod Annotations
   podAnnotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: 'http-metrics'
+    prometheus.io/port: '8080'
 
   nodeSelector: {}
   affinity:
@@ -839,7 +839,7 @@ table_manager:
   ## Pod Annotations
   podAnnotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: 'http-metrics'
+    prometheus.io/port: '8080'
 
   nodeSelector: {}
   affinity: {}
@@ -912,7 +912,7 @@ configs:
   ## Pod Annotations
   podAnnotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: 'http-metrics'
+    prometheus.io/port: '8080'
 
   nodeSelector: {}
   affinity: {}
@@ -997,7 +997,7 @@ nginx:
   ## Pod Annotations
   podAnnotations:
     prometheus.io/scrape: ''
-    prometheus.io/port: 'http-metrics'
+    prometheus.io/port: '80'
 
   nodeSelector: {}
   affinity: {}
@@ -1069,7 +1069,7 @@ store_gateway:
   ## Pod Annotations
   podAnnotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: 'http-metrics'
+    prometheus.io/port: '8080'
 
   nodeSelector: {}
   affinity:
@@ -1189,7 +1189,7 @@ compactor:
   ## Pod Annotations
   podAnnotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: 'http-metrics'
+    prometheus.io/port: '8080'
 
   nodeSelector: {}
   affinity:


### PR DESCRIPTION
This changes the annotations to use port number, so that prometheus can scrape the targets.

This means that port number has to be managed in multiple places, unfortunately, but this is a temporary solution.