### PR TITLE
Use helm3 in the ci script

### DIFF
--- a/hack/ci/deploy-dev.sh
+++ b/hack/ci/deploy-dev.sh
@@ -49,7 +49,7 @@ kubectl apply -f dashboards/
 
 echodate ""
 echodate "Installing Consul for Cortex"
-helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install consul charts/consul --values config/consul/values.yaml
+helm3 --namespace ${MLA_NS} upgrade --atomic --create-namespace --install consul charts/consul --values config/consul/values.yaml
 
 echodate ""
 echodate "Installing Cortex"


### PR DESCRIPTION
This PR uses helm3 in the ci script explicitly so that the CI job can pass