### PR TITLE
fix mla consul

### DIFF
--- a/config/consul/values.yaml
+++ b/config/consul/values.yaml
@@ -1,2 +1,18 @@
 client:
   enabled: false
+server:
+  replicas: 3
+  # we need a more relaxed affinity as the default one, so
+  # the chart can be run on the e2e clusters which have
+  # fewer nodes than consul replicas
+  affinity: |
+    podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: {{ template "consul.name" . }}
+                    release: "{{ .Release.Name }}"
+                    component: server
+                topologyKey: kubernetes.io/hostname

--- a/config/consul/values.yaml
+++ b/config/consul/values.yaml
@@ -1,0 +1,2 @@
+client:
+  enabled: false


### PR DESCRIPTION
This PR solves the failing CI for https://github.com/kubermatic/kubermatic/pull/8189

It has been tested locally with a single-node cluster and should also work with the e2e tests smaller cluster.

```
❯ kc get nodes
NAME                     STATUS   ROLES                  AGE    VERSION
mla-test-control-plane   Ready    control-plane,master   3h2m   v1.21.1
❯ kc get pods
NAME                     READY   STATUS    RESTARTS   AGE
consul-consul-server-0   1/1     Running   0          20m
consul-consul-server-1   1/1     Running   0          20m
consul-consul-server-2   1/1     Running   0          21m
```

It has also been tested on the seed-dev cluster
```
❯ kc get pods | grep consul
consul-consul-server-0                             1/1     Running     0          9m26s
consul-consul-server-1                             1/1     Running     0          9m26s
consul-consul-server-2                             1/1     Running     0          9m26s
```

Additionally I also removed the consul client, as it is not needed for our mla use-case