### PR TITLE
Allow using existing minio in MLA setup

### DIFF
--- a/charts/mla-secrets/Chart.yaml
+++ b/charts/mla-secrets/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: mla-secrets
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 description: A Helm chart to manage MLA (Monitoring, Logging, Alerting) related secrets.
 keywords:

--- a/charts/mla-secrets/templates/grafana-secret.yaml
+++ b/charts/mla-secrets/templates/grafana-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.grafana.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,3 +14,4 @@ data:
   {{- if and .Values.grafana.ldap.enabled .Values.grafana.ldap.config }}
   ldap-toml: {{ tpl .Values.grafana.ldap.config $ | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/mla-secrets/templates/minio-secret.yaml
+++ b/charts/mla-secrets/templates/minio-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.minio.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,4 +23,5 @@ data:
 {{- end }}
 {{- if .Values.minio.etcd.clientCertKey }}
   etcd_client_cert_key.pem: {{ .Values.minio.etcd.clientCertKey | toString | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/mla-secrets/values.yaml
+++ b/charts/mla-secrets/values.yaml
@@ -14,8 +14,8 @@
 
 
 minio:
-  ## Enable if you want to generate a minio secret.
-  enabled: false
+  ## Set enabled to false if you want to re-using an existing secret for minio.
+  enabled: true
   ## Set default accesskey, secretkey
   ## AccessKey and secretKey is generated when not set
   accessKey: ""
@@ -42,8 +42,8 @@ minio:
     clientCertKey: ""
 
 grafana:
-  ## Enable if you want to generate a grafana secret.
-  enabled: false
+  ## Set enabled to false if you want to re-using an existing secret for grafana.
+  enabled: true
   adminUser: admin
 #  adminPassword: strongpassword
 

--- a/charts/mla-secrets/values.yaml
+++ b/charts/mla-secrets/values.yaml
@@ -14,6 +14,8 @@
 
 
 minio:
+  ## Enable if you want to generate a minio secret.
+  enabled: false
   ## Set default accesskey, secretkey
   ## AccessKey and secretKey is generated when not set
   accessKey: ""
@@ -40,6 +42,8 @@ minio:
     clientCertKey: ""
 
 grafana:
+  ## Enable if you want to generate a grafana secret.
+  enabled: false
   adminUser: admin
 #  adminPassword: strongpassword
 

--- a/charts/mla-secrets/values.yaml
+++ b/charts/mla-secrets/values.yaml
@@ -14,7 +14,7 @@
 
 
 minio:
-  ## Set enabled to false if you want to re-using an existing secret for minio.
+  ## Set enabled to false if you want to re-use an existing secret for minio.
   enabled: true
   ## Set default accesskey, secretkey
   ## AccessKey and secretKey is generated when not set
@@ -42,7 +42,7 @@ minio:
     clientCertKey: ""
 
 grafana:
-  ## Set enabled to false if you want to re-using an existing secret for grafana.
+  ## Set enabled to false if you want to re-use an existing secret for grafana.
   enabled: true
   adminUser: admin
 #  adminPassword: strongpassword

--- a/config/mla-secrets/values.yaml
+++ b/config/mla-secrets/values.yaml
@@ -13,4 +13,10 @@
 # limitations under the License.
 
 grafana:
+  ## Disable this if you want to use secret from existing grafana installation.
+  enabled: true
   adminuser: admin
+
+minio:
+  ## Disable this if you want to use secret from existing minio installation.
+  enabled: true

--- a/config/mla-secrets/values.yaml
+++ b/config/mla-secrets/values.yaml
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 grafana:
-  ## Disable this if you want to use secret from existing grafana installation.
+  ## Set enabled to false if you want to re-using an existing secret for grafana.
   enabled: true
   adminuser: admin
 
 minio:
-  ## Disable this if you want to use secret from existing minio installation.
+  ## Set enabled to false if you want to re-using an existing secret for minio.
   enabled: true

--- a/config/mla-secrets/values.yaml
+++ b/config/mla-secrets/values.yaml
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 grafana:
-  ## Set enabled to false if you want to re-using an existing secret for grafana.
+  ## Set enabled to false if you want to re-use an existing secret for grafana.
   enabled: true
   adminuser: admin
 
 minio:
-  ## Set enabled to false if you want to re-using an existing secret for minio.
+  ## Set enabled to false if you want to re-use an existing secret for minio.
   enabled: true

--- a/hack/deploy-seed.sh
+++ b/hack/deploy-seed.sh
@@ -1,8 +1,24 @@
 #!/usr/bin/env bash
 
-echo ""
-echo "Installing Minio"
-helm --namespace mla upgrade --atomic --create-namespace --install minio charts/minio --values config/minio/values.yaml
+if [ "$1" = "-h" ]; then
+   cat << EOF
+Usage: deploy-seed.sh [-skip-minio]
+
+Deploy MLA backend components on a KKP Seed cluster.
+-skip-minio flag can be used if you want to configure MLA backend components to user existing minio in the cluster, if this flag is not specified, it will deploy a minio instance for you.
+EOF
+   exit 0
+fi
+
+if [ "$1" != "-skip-minio" ]; then
+    echo ""
+    echo "Installing Minio"
+    helm --namespace mla upgrade --atomic --create-namespace --install minio charts/minio --values config/minio/values.yaml
+
+    echo ""
+    echo "Installing Minio Bucket Lifecycle Manager"
+    helm --namespace mla upgrade --atomic --create-namespace --install minio-lifecycle-mgr charts/minio-lifecycle-mgr --values config/minio-lifecycle-mgr/values.yaml
+fi
 
 echo ""
 echo "Installing Grafana"
@@ -29,7 +45,3 @@ helm --namespace mla upgrade --atomic --create-namespace --install loki-distribu
 echo ""
 echo "Installing Alertmanager Proxy"
 helm --namespace mla upgrade --atomic --create-namespace --install alertmanager-proxy charts/alertmanager-proxy
-
-echo ""
-echo "Installing Minio Bucket Lifecycle Manager"
-helm --namespace mla upgrade --atomic --create-namespace --install minio-lifecycle-mgr charts/minio-lifecycle-mgr --values config/minio-lifecycle-mgr/values.yaml

--- a/hack/deploy-seed.sh
+++ b/hack/deploy-seed.sh
@@ -2,19 +2,34 @@
 
 if [ "$1" = "-h" ]; then
    cat << EOF
-Usage: deploy-seed.sh [-skip-minio]
-
+Usage: deploy-seed.sh [--skip-minio] [--skip-minio-lifecycle-mgr]
 Deploy MLA backend components on a KKP Seed cluster.
--skip-minio flag can be used if you want to configure MLA backend components to user existing minio in the cluster, if this flag is not specified, it will deploy a minio instance for you.
+--skip-minio               this can be used if you want to configure MLA backend components to user existing minio in the cluster, if this flag is not specified, it will deploy a minio instance for you.
+--skip-minio-lifecycle-mgr this will skip the installation of minio lifecycle manager.
 EOF
    exit 0
 fi
 
-if [ "$1" != "-skip-minio" ]; then
+skip_minio=false
+skip_minio_lifecycle_mgr=false
+
+for var in $@
+do
+    if [ "$var" = "--skip-minio" ]; then
+        skip_minio=true
+    fi
+    if [ "$var" = "--skip-minio-lifecycle-mgr" ]; then
+        skip_minio_lifecycle_mgr=true
+    fi
+done
+
+if [ "$skip_minio" != true ]; then
     echo ""
     echo "Installing Minio"
     helm --namespace mla upgrade --atomic --create-namespace --install minio charts/minio --values config/minio/values.yaml
+fi
 
+if [ "$skip_minio_lifecycle_mgr" != true ]; then
     echo ""
     echo "Installing Minio Bucket Lifecycle Manager"
     helm --namespace mla upgrade --atomic --create-namespace --install minio-lifecycle-mgr charts/minio-lifecycle-mgr --values config/minio-lifecycle-mgr/values.yaml


### PR DESCRIPTION
This PR does the following things:
1. Modify the mla-secrets charts by adding `enabled` fields, so that users can choose if they want to use the existing secrets or let the script create secrets for them, this is needed for configuring MLA components to work with existing minio.
2. Add a flag `-skip-minio` to `deploy-seed.sh`, so that admin can skip minio installation during setup