### PR TITLE
Fixes for issues observed in monitoring medium to large user-clusters

### DIFF
--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -69,6 +69,7 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
 {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -209,6 +209,7 @@ securityContext:
   runAsUser: 1000
   runAsGroup: 1000
   fsGroup: 1000
+  fsGroupChangePolicy: "OnRootMismatch"
 
 # Additational pod annotations
 podAnnotations: {}

--- a/config/cortex/values.yaml
+++ b/config/cortex/values.yaml
@@ -229,6 +229,7 @@ config:
       kvstore:
         store: memberlist
   compactor:
+    block_deletion_marks_migration_enabled: false
     data_dir: /data/cortex/compactor
     compaction_interval: 30m
     sharding_enabled: true
@@ -289,6 +290,7 @@ config:
   limits:
     max_query_lookback: 168h
     accept_ha_samples: true
+    max_label_names_per_series: 40
 
 runtimeconfigmap:
   # -- If true, a configmap for the `runtime_config` will be created.


### PR DESCRIPTION
Fixes #76 

This PR brings following fixes:
1. If we have too many files in Minio - minio pod cannot mount the volume. (more details of the issue and fix suggested in #76)
2. Cortex Compactor fails to start if we have too many metrics in the storage. Cortex team has provided [this suggestion](https://cortexmetrics.io/docs/blocks-storage/production-tips/#ensure-deletion-marks-migration-is-disabled-after-first-run) to turn off the deleted_blocks_mark migration.
3. We observed that some of pods were not getting scraped due to random limit of 30 labels defaulted in cortex chart. So relaxed this limit a bit to 40.