### PR TITLE
Fix provisioning of default Grafana dashboards

### DIFF
--- a/config/grafana/values.yaml
+++ b/config/grafana/values.yaml
@@ -30,13 +30,21 @@ dashboardProviders:
   dashboardproviders.yaml:
     apiVersion: 1
     providers:
-    - name: 'default'
-      folder: ''
-      org_id: 1
-      type: file
-      disableDeletion: false
-      options:
-        path: /var/lib/grafana/dashboards/default
+      - name: "kubernetes"
+        folder: "Kubernetes"
+        org_id: 1
+        type: file
+        disableDeletion: false
+        options:
+          path: /var/lib/grafana/dashboards/kubernetes
+      - name: "kubermatic"
+        folder: "Kubermatic"
+        org_id: 1
+        type: file
+        disableDeletion: false
+        options:
+          path: /var/lib/grafana/dashboards/kubermatic
 
-dashboards:
-  default:
+dashboardsConfigMaps:
+  kubernetes: grafana-dashboards-kubernetes-overview
+  kubermatic: grafana-dashboards-kkp-kubernetes


### PR DESCRIPTION
Changed the Grafana Helm values to automatically provision the provided
Grafana dashboards for Kubernetes / Kubermatic (which are now stored in
separate ConfigMaps) by default.