### PR TITLE
Mla large cluster stability fixes

### DIFF
--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -69,6 +69,7 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
 {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -209,6 +209,7 @@ securityContext:
   runAsUser: 1000
   runAsGroup: 1000
   fsGroup: 1000
+  fsGroupChangePolicy: "OnRootMismatch"
 
 # Additational pod annotations
 podAnnotations: {}

--- a/config/cortex/values.yaml
+++ b/config/cortex/values.yaml
@@ -38,6 +38,9 @@ ruler:
     - name: cortex-runtime-config
       configMap:
         name: cortex-runtime-config
+  resources:
+    requests:
+      cpu: 5m
 
 compactor:
   replicas: 1
@@ -82,6 +85,9 @@ store_gateway:
     - name: cortex-runtime-config
       configMap:
         name: cortex-runtime-config
+  resources:
+    requests:
+      cpu: 5m
 
 ingester:
   replicas: 3
@@ -140,6 +146,9 @@ querier:
     - name: cortex-runtime-config
       configMap:
         name: cortex-runtime-config
+  resources:
+    requests:
+      cpu: 5m
 
 query_frontend:
   replicas: 1
@@ -152,6 +161,9 @@ query_frontend:
     - name: cortex-runtime-config
       configMap:
         name: cortex-runtime-config
+  resources:
+    requests:
+      cpu: 5m
 
 tags:
   blocks-storage-memcached: true
@@ -298,13 +310,22 @@ runtimeconfigmap:
   create: false
 
 memcached-blocks-metadata:
+  resources:
+    requests:
+      cpu: 5m
   serviceAccount:
     create: false
 
 memcached-blocks-index:
+  resources:
+    requests:
+      cpu: 5m
   serviceAccount:
     create: false
 
 memcached-blocks:
+  resources:
+    requests:
+      cpu: 5m
   serviceAccount:
     create: false

--- a/config/cortex/values.yaml
+++ b/config/cortex/values.yaml
@@ -229,6 +229,7 @@ config:
       kvstore:
         store: memberlist
   compactor:
+    block_deletion_marks_migration_enabled: false
     data_dir: /data/cortex/compactor
     compaction_interval: 30m
     sharding_enabled: true
@@ -289,6 +290,7 @@ config:
   limits:
     max_query_lookback: 168h
     accept_ha_samples: true
+    max_label_names_per_series: 40
 
 runtimeconfigmap:
   # -- If true, a configmap for the `runtime_config` will be created.

--- a/config/loki/values.yaml
+++ b/config/loki/values.yaml
@@ -1,7 +1,4 @@
 loki:
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "http-metrics"
   config: |
     server:
       http_listen_port: 3100
@@ -101,24 +98,43 @@ tableManager:
   extraEnvFrom:
     - secretRef:
         name: minio
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3100"
+
 
 memcachedExporter:
   enabled: true
 
 memcachedChunks:
   enabled: true
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "11211"
 
 memcachedFrontend:
   enabled: true
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "11211"
 
 memcachedIndexQueries:
   enabled: true
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "11211"
 
 memcachedIndexWrites:
   enabled: true
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "11211"
 
 distributor:
   replicas: 2
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3100"
 
 ingester:
   replicas: 3
@@ -131,6 +147,9 @@ ingester:
   persistence:
     enabled: true
     storageClass: "kubermatic-fast"
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3100"
 
 querier:
   replicas: 1
@@ -143,6 +162,14 @@ querier:
   persistence:
     enabled: true
     storageClass: "kubermatic-fast"
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3100"
+
+queryFrontend:
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3100"
 
 gateway:
   enabled: false
@@ -159,6 +186,9 @@ ruler:
   extraEnvFrom:
     - secretRef:
         name: minio
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3100"
 
 compactor:
   enabled: true
@@ -168,3 +198,6 @@ compactor:
   extraEnvFrom:
     - secretRef:
         name: minio
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3100"

--- a/config/loki/values.yaml
+++ b/config/loki/values.yaml
@@ -110,25 +110,25 @@ memcachedChunks:
   enabled: true
   podAnnotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "11211"
+    prometheus.io/port: "9150"
 
 memcachedFrontend:
   enabled: true
   podAnnotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "11211"
+    prometheus.io/port: "9150"
 
 memcachedIndexQueries:
   enabled: true
   podAnnotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "11211"
+    prometheus.io/port: "9150"
 
 memcachedIndexWrites:
   enabled: true
   podAnnotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "11211"
+    prometheus.io/port: "9150"
 
 distributor:
   replicas: 2


### PR DESCRIPTION
Supercedes #77.
Fixes #76, #78

Changes to fix issues observed in large cluster deployment of user-cluster MLA.

This PR brings following fixes:

1. If we have too many files in Minio - minio pod cannot mount the volume. (more details of the issue and fix suggested in https://github.com/kubermatic/mla/issues/76)
2. Cortex Compactor fails to start if we have too many metrics in the storage. Cortex team has provided [this suggestion](https://cortexmetrics.io/docs/blocks-storage/production-tips/#ensure-deletion-marks-migration-is-disabled-after-first-run) to turn off the deleted_blocks_mark migration.
3. We observed that some of pods were not getting scraped due to random limit of 30 labels defaulted in cortex chart. So relaxed this limit a bit to 40.
4. We observed that we had overprovisioned almost all the MLA related pods with high CPU slices which was not getting used as much so we rationalized the CPU request which blocks CPU unnecessarily
5. Loki distributed charts related prometheus scraping ports are fixed for all deployments now