### PR TITLE
Download dependencies during the deployment of mla

### DIFF
--- a/hack/ci/deploy-dev.sh
+++ b/hack/ci/deploy-dev.sh
@@ -37,10 +37,12 @@ echodate "Successfully got secrets for dev from Vault"
 ## We have to use helm3 since `--create-namespace` is not available in helm2
 echodate ""
 echodate "Installing Minio"
+helm3 dep build charts/minio
 helm3 --namespace ${MLA_NS} upgrade --atomic --create-namespace --install minio charts/minio --values config/minio/values.yaml
 
 echodate ""
 echodate "Installing Grafana"
+helm3 dep build charts/grafana
 helm3 --namespace ${MLA_NS} upgrade --atomic --create-namespace --install grafana charts/grafana --values config/grafana/values.yaml
 
 echo ""
@@ -49,6 +51,7 @@ kubectl apply -f dashboards/
 
 echodate ""
 echodate "Installing Consul for Cortex"
+helm3 dep build charts/consul
 helm3 --namespace ${MLA_NS} upgrade --atomic --create-namespace --install consul charts/consul --values config/consul/values.yaml
 
 echodate ""
@@ -59,6 +62,7 @@ helm3 --namespace ${MLA_NS} upgrade --atomic --create-namespace --install cortex
 
 echodate ""
 echodate "Installing Loki"
+helm3 dep build charts/loki-distributed
 helm3 --namespace ${MLA_NS} upgrade --atomic --create-namespace --install loki-distributed charts/loki-distributed --values config/loki/values.yaml --timeout 600s
 
 echodate ""


### PR DESCRIPTION
After merging #82, deployment stopped working because upstream charts were not fetched. This fixes the problem.