### PR TITLE
Remove manual installation of cortex runtime-config ConfigMap

### DIFF
--- a/config/cortex/runtime-config.yaml
+++ b/config/cortex/runtime-config.yaml
@@ -1,1 +1,0 @@
-overrides:

--- a/hack/ci/deploy-dev.sh
+++ b/hack/ci/deploy-dev.sh
@@ -55,7 +55,6 @@ helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install consul 
 
 echodate ""
 echodate "Installing Cortex"
-kubectl create -n mla configmap cortex-runtime-config --from-file=config/cortex/runtime-config.yaml || true
 helm dependency update charts/cortex  # need that to store memcached in charts directory
 helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install cortex charts/cortex --values config/cortex/values.yaml --timeout 1200s
 

--- a/hack/deploy-seed.sh
+++ b/hack/deploy-seed.sh
@@ -53,7 +53,6 @@ helm --namespace mla upgrade --atomic --create-namespace --install consul charts
 
 echo ""
 echo "Installing Cortex"
-kubectl create -n mla configmap cortex-runtime-config --from-file=config/cortex/runtime-config.yaml || true
 helm dependency update charts/cortex  # need that to store memcached in charts directory
 helm --namespace mla upgrade --atomic --create-namespace --install cortex charts/cortex --values config/cortex/values.yaml --timeout 1200s
 


### PR DESCRIPTION
Remove manual installation of cortex runtime-config ConfigMap as it has been added into Cortex helm chart v0.7.0
(https://github.com/cortexproject/cortex-helm-chart/blob/v0.7.0/templates/runtime-configmap.yaml)