### PR TITLE
Limit CI job on 4Gi memory

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -29,4 +29,4 @@ postsubmits:
               memory: 1Gi
             limits:
               cpu: 2
-              memory: 2Gi
+              memory: 4Gi


### PR DESCRIPTION
cortex chart's helm dep build takes slightly over 2Gi mem (previous limit)