### PR TITLE
Revert cortex runtime config changes

### DIFF
--- a/config/cortex/runtime-config.yaml
+++ b/config/cortex/runtime-config.yaml
@@ -1,0 +1,1 @@
+overrides:

--- a/config/cortex/values.yaml
+++ b/config/cortex/values.yaml
@@ -254,7 +254,7 @@ cortex:
         - cortex-ingester-headless
     runtime_config:
       period: "10s"
-      file: "/etc/cortex-runtime-cfg/runtime_config.yaml"
+      file: "/etc/cortex-runtime-cfg/runtime-config.yaml"
     ruler:
       enable_alertmanager_discovery: true
       enable_api: true

--- a/config/cortex/values.yaml
+++ b/config/cortex/values.yaml
@@ -308,7 +308,7 @@ cortex:
   runtimeconfigmap:
     # -- If true, a configmap for the `runtime_config` will be created.
     # If false, the configmap _must_ exist already on the cluster or pods will fail to create.
-    create: true
+    create: false
 
   memcached-blocks-metadata:
     resources:

--- a/hack/ci/deploy-dev.sh
+++ b/hack/ci/deploy-dev.sh
@@ -55,6 +55,7 @@ helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install consul 
 
 echodate ""
 echodate "Installing Cortex"
+kubectl create -n mla configmap cortex-runtime-config --from-file=config/cortex/runtime-config.yaml || true
 helm --namespace ${MLA_NS} upgrade --atomic --create-namespace --install cortex charts/cortex --values config/cortex/values.yaml --timeout 1200s
 
 echodate ""

--- a/hack/deploy-seed.sh
+++ b/hack/deploy-seed.sh
@@ -53,6 +53,7 @@ helm --namespace mla upgrade --atomic --create-namespace --install consul charts
 
 echo ""
 echo "Installing Cortex"
+kubectl create -n mla configmap cortex-runtime-config --from-file=config/cortex/runtime-config.yaml || true
 helm --namespace mla upgrade --atomic --create-namespace --install cortex charts/cortex --values config/cortex/values.yaml --timeout 1200s
 
 echo ""


### PR DESCRIPTION
Unfortunately, it is not possible to use Cortex runtime-config from the Cortex helm chart without changing the KKP controller code, as the config file name is part of the KKP code (https://github.com/kubermatic/kubermatic/blob/1b8eb244d2ad73f1617a933a6317b227ca58e562/pkg/controller/seed-controller-manager/mla/ratelimit_cortex_controller.go#L46). Thus in order to keep compatibility with KKP 2.18 & 2.19, we need to keep it as it was for now.

We can make this change both in MLA and KKP repos in the release for KKP 2.20.