### PR TITLE
Add workaroud for Cortex Alertmanager service discovery bug

### DIFF
--- a/charts/cortex/templates/cortex-alertmanager-headless-kkp.yaml
+++ b/charts/cortex/templates/cortex-alertmanager-headless-kkp.yaml
@@ -1,0 +1,22 @@
+# This is a KKP-specific headless alertmanager service, used to work around
+# the Cortex helm chart bug in chart versions below v1.0.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: cortex-alertmanager-headless-kkp
+spec:
+  clusterIP: None
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: http-metrics
+    port: 8080
+    protocol: TCP
+    targetPort: http-metrics
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/instance: cortex
+    app.kubernetes.io/name: cortex
+  sessionAffinity: None
+  type: ClusterIP

--- a/charts/cortex/test/config.yaml.out
+++ b/charts/cortex/test/config.yaml.out
@@ -3,12 +3,12 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: RELEASE-NAME-cortex-alertmanager
+  name: release-name-cortex-alertmanager
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: alertmanager
   maxUnavailable: 1
 ---
@@ -24,12 +24,12 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: RELEASE-NAME-cortex-distributor
+  name: release-name-cortex-distributor
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
@@ -37,7 +37,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: distributor
   maxUnavailable: 1
 ---
@@ -45,12 +45,12 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: RELEASE-NAME-cortex-ingester
+  name: release-name-cortex-ingester
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
@@ -58,7 +58,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: ingester
   maxUnavailable: 1
 ---
@@ -66,12 +66,12 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: RELEASE-NAME-cortex-nginx
+  name: release-name-cortex-nginx
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: nginx
@@ -79,7 +79,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: nginx
   maxUnavailable: 1
 ---
@@ -87,12 +87,12 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: RELEASE-NAME-cortex
+  name: release-name-cortex
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
@@ -104,12 +104,12 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
-  name: RELEASE-NAME-memcached-blocks-index
+  name: release-name-memcached-blocks-index
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-index
     helm.sh/chart: memcached-blocks-index-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: cortex/charts/memcached-blocks-metadata/templates/serviceaccount.yaml
@@ -117,12 +117,12 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
-  name: RELEASE-NAME-memcached-blocks-metadata
+  name: release-name-memcached-blocks-metadata
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-metadata
     helm.sh/chart: memcached-blocks-metadata-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: cortex/charts/memcached-blocks/templates/serviceaccount.yaml
@@ -130,55 +130,39 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
-  name: RELEASE-NAME-memcached-blocks
+  name: release-name-memcached-blocks
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks
     helm.sh/chart: memcached-blocks-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: cortex/charts/cortex/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: RELEASE-NAME-cortex
+  name: release-name-cortex
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
 data:
-  cortex.yaml: YWxlcnRtYW5hZ2VyOgogIGRhdGFfZGlyOiAvZGF0YS9jb3J0ZXgvYWxlcnQtZGF0YQogIGVuYWJsZV9hcGk6IHRydWUKICBleHRlcm5hbF91cmw6IC9hcGkvcHJvbS9hbGVydG1hbmFnZXIKICBzdG9yYWdlOgogICAgczM6CiAgICAgIGJ1Y2tldG5hbWVzOiBhbGVydG1hbmFnZXIKICAgICAgZW5kcG9pbnQ6IG1pbmlvOjkwMDAKICAgICAgaW5zZWN1cmU6IHRydWUKICAgICAgczNmb3JjZXBhdGhzdHlsZTogdHJ1ZQogICAgdHlwZTogczMKYXBpOgogIHByb21ldGhldXNfaHR0cF9wcmVmaXg6IC9wcm9tZXRoZXVzCiAgcmVzcG9uc2VfY29tcHJlc3Npb25fZW5hYmxlZDogdHJ1ZQphdXRoX2VuYWJsZWQ6IHRydWUKYmxvY2tzX3N0b3JhZ2U6CiAgYmFja2VuZDogczMKICBidWNrZXRfc3RvcmU6CiAgICBidWNrZXRfaW5kZXg6CiAgICAgIGVuYWJsZWQ6IHRydWUKICAgIGlnbm9yZV9kZWxldGlvbl9tYXJrX2RlbGF5OiAxaAogICAgc3luY19kaXI6IC9kYXRhCiAgczM6CiAgICBidWNrZXRfbmFtZTogY29ydGV4CiAgICBlbmRwb2ludDogbWluaW86OTAwMAogICAgaW5zZWN1cmU6IHRydWUKICB0c2RiOgogICAgY2xvc2VfaWRsZV90c2RiX3RpbWVvdXQ6IDM2NW0KICAgIGRpcjogL2RhdGEKICAgIGZsdXNoX2Jsb2Nrc19vbl9zaHV0ZG93bjogdHJ1ZQogICAgcmV0ZW50aW9uX3BlcmlvZDogMzY1bQogICAgd2FsX2NvbXByZXNzaW9uX2VuYWJsZWQ6IHRydWUKY2h1bmtfc3RvcmU6CiAgY2h1bmtfY2FjaGVfY29uZmlnOgogICAgbWVtY2FjaGVkOgogICAgICBleHBpcmF0aW9uOiAxaAogICAgbWVtY2FjaGVkX2NsaWVudDoKICAgICAgdGltZW91dDogMXMKY29tcGFjdG9yOgogIGJsb2NrX2RlbGV0aW9uX21hcmtzX21pZ3JhdGlvbl9lbmFibGVkOiBmYWxzZQogIGNvbXBhY3Rpb25faW50ZXJ2YWw6IDMwbQogIGRhdGFfZGlyOiAvZGF0YS9jb3J0ZXgvY29tcGFjdG9yCiAgc2hhcmRpbmdfZW5hYmxlZDogdHJ1ZQogIHNoYXJkaW5nX3Jpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdApkaXN0cmlidXRvcjoKICBoYV90cmFja2VyOgogICAgZW5hYmxlX2hhX3RyYWNrZXI6IHRydWUKICAgIGt2c3RvcmU6CiAgICAgIGNvbnN1bDoKICAgICAgICBob3N0OiBjb25zdWwtY29uc3VsLXNlcnZlcjo4NTAwCiAgICAgIHN0b3JlOiBjb25zdWwKICBwb29sOgogICAgaGVhbHRoX2NoZWNrX2luZ2VzdGVyczogdHJ1ZQogIHJpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdAogIHNoYXJkX2J5X2FsbF9sYWJlbHM6IHRydWUKZnJvbnRlbmQ6CiAgbG9nX3F1ZXJpZXNfbG9uZ2VyX3RoYW46IDEwcwppbmdlc3RlcjoKICBsaWZlY3ljbGVyOgogICAgZmluYWxfc2xlZXA6IDBzCiAgICBqb2luX2FmdGVyOiAwcwogICAgbnVtX3Rva2VuczogNTEyCiAgICByaW5nOgogICAgICBrdnN0b3JlOgogICAgICAgIGNvbnN1bDoKICAgICAgICAgIGNvbnNpc3RlbnRfcmVhZHM6IHRydWUKICAgICAgICAgIGhvc3Q6IGNvbnN1bDo4NTAwCiAgICAgICAgICBodHRwX2NsaWVudF90aW1lb3V0OiAyMHMKICAgICAgICBwcmVmaXg6IGNvbGxlY3RvcnMvCiAgICAgICAgc3RvcmU6IG1lbWJlcmxpc3QKICAgICAgcmVwbGljYXRpb25fZmFjdG9yOiAzCiAgbWF4X3RyYW5zZmVyX3JldHJpZXM6IDAKaW5nZXN0ZXJfY2xpZW50OgogIGdycGNfY2xpZW50X2NvbmZpZzoKICAgIG1heF9yZWN2X21zZ19zaXplOiAxMDQ4NTc2MDAKICAgIG1heF9zZW5kX21zZ19zaXplOiAxMDQ4NTc2MDAKbGltaXRzOgogIGFjY2VwdF9oYV9zYW1wbGVzOiB0cnVlCiAgZW5mb3JjZV9tZXRyaWNfbmFtZTogZmFsc2UKICBtYXhfbGFiZWxfbmFtZXNfcGVyX3NlcmllczogNDAKICBtYXhfcXVlcnlfbG9va2JhY2s6IDE2OGgKICByZWplY3Rfb2xkX3NhbXBsZXM6IHRydWUKICByZWplY3Rfb2xkX3NhbXBsZXNfbWF4X2FnZTogMTY4aAptZW1iZXJsaXN0OgogIGJpbmRfcG9ydDogNzk0NgogIGpvaW5fbWVtYmVyczoKICAtIGNvcnRleC1pbmdlc3Rlci1oZWFkbGVzcwpxdWVyaWVyOgogIGFjdGl2ZV9xdWVyeV90cmFja2VyX2RpcjogL2RhdGEvY29ydGV4L3F1ZXJpZXIKICBxdWVyeV9pbmdlc3RlcnNfd2l0aGluOiAzNjVtCiAgcXVlcnlfc3RvcmVfYWZ0ZXI6IDM2MG0KICBzdG9yZV9nYXRld2F5X2FkZHJlc3NlczogfC0KICAgIApxdWVyeV9yYW5nZToKICBhbGlnbl9xdWVyaWVzX3dpdGhfc3RlcDogdHJ1ZQogIGNhY2hlX3Jlc3VsdHM6IHRydWUKICByZXN1bHRzX2NhY2hlOgogICAgY2FjaGU6CiAgICAgIG1lbWNhY2hlZDoKICAgICAgICBleHBpcmF0aW9uOiAxaAogICAgICBtZW1jYWNoZWRfY2xpZW50OgogICAgICAgIHRpbWVvdXQ6IDFzCiAgc3BsaXRfcXVlcmllc19ieV9pbnRlcnZhbDogMjRoCnJ1bGVyOgogIGVuYWJsZV9hbGVydG1hbmFnZXJfZGlzY292ZXJ5OiB0cnVlCiAgZW5hYmxlX2FwaTogdHJ1ZQogIHJpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdAogIHN0b3JhZ2U6CiAgICBzMzoKICAgICAgYnVja2V0bmFtZXM6IGNvcnRleC1ydWxlcgogICAgICBlbmRwb2ludDogbWluaW86OTAwMAogICAgICBpbnNlY3VyZTogdHJ1ZQogICAgICBzM2ZvcmNlcGF0aHN0eWxlOiB0cnVlCiAgICB0eXBlOiBzMwpydW50aW1lX2NvbmZpZzoKICBmaWxlOiAvZXRjL2NvcnRleC1ydW50aW1lLWNmZy9ydW50aW1lX2NvbmZpZy55YW1sCiAgcGVyaW9kOiAxMHMKc2NoZW1hOgogIGNvbmZpZ3M6CiAgLSBjaHVua3M6CiAgICAgIHBlcmlvZDogMTY4aAogICAgICBwcmVmaXg6IGNodW5rc18KICAgIGZyb206ICIyMDIwLTExLTAxIgogICAgaW5kZXg6CiAgICAgIHBlcmlvZDogMTY4aAogICAgICBwcmVmaXg6IGluZGV4XwogICAgb2JqZWN0X3N0b3JlOiBjYXNzYW5kcmEKICAgIHNjaGVtYTogdjEwCiAgICBzdG9yZTogY2Fzc2FuZHJhCnNlcnZlcjoKICBncnBjX2xpc3Rlbl9wb3J0OiA5MDk1CiAgZ3JwY19zZXJ2ZXJfbWF4X2NvbmN1cnJlbnRfc3RyZWFtczogMTAwMAogIGdycGNfc2VydmVyX21heF9yZWN2X21zZ19zaXplOiAxMDQ4NTc2MDAKICBncnBjX3NlcnZlcl9tYXhfc2VuZF9tc2dfc2l6ZTogMTA0ODU3NjAwCiAgaHR0cF9saXN0ZW5fcG9ydDogODA4MApzdG9yYWdlOgogIGF6dXJlOiB7fQogIGNhc3NhbmRyYToKICAgIGF1dGg6IHRydWUKICAgIGtleXNwYWNlOiBjb3J0ZXgKICBlbmdpbmU6IGJsb2NrcwogIGluZGV4X3F1ZXJpZXNfY2FjaGVfY29uZmlnOgogICAgbWVtY2FjaGVkOgogICAgICBleHBpcmF0aW9uOiAxaAogICAgbWVtY2FjaGVkX2NsaWVudDoKICAgICAgdGltZW91dDogMXMKc3RvcmVfZ2F0ZXdheToKICBzaGFyZGluZ19lbmFibGVkOiB0cnVlCiAgc2hhcmRpbmdfcmluZzoKICAgIGt2c3RvcmU6CiAgICAgIHN0b3JlOiBtZW1iZXJsaXN0CiAgICByZXBsaWNhdGlvbl9mYWN0b3I6IDIKdGFibGVfbWFuYWdlcjoKICByZXRlbnRpb25fZGVsZXRlc19lbmFibGVkOiBmYWxzZQogIHJldGVudGlvbl9wZXJpb2Q6IDBz
----
-# Source: cortex/charts/cortex/templates/runtime-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: RELEASE-NAME-cortex-runtime-config
-  namespace: default
-  labels:
-    helm.sh/chart: cortex-0.7.0
-    app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
-    app.kubernetes.io/version: "v1.10.0"
-    app.kubernetes.io/managed-by: Helm
-data:
-  runtime_config.yaml: |
-    {}
+  cortex.yaml: YWxlcnRtYW5hZ2VyOgogIGRhdGFfZGlyOiAvZGF0YS9jb3J0ZXgvYWxlcnQtZGF0YQogIGVuYWJsZV9hcGk6IHRydWUKICBleHRlcm5hbF91cmw6IC9hcGkvcHJvbS9hbGVydG1hbmFnZXIKICBzdG9yYWdlOgogICAgczM6CiAgICAgIGJ1Y2tldG5hbWVzOiBhbGVydG1hbmFnZXIKICAgICAgZW5kcG9pbnQ6IG1pbmlvOjkwMDAKICAgICAgaW5zZWN1cmU6IHRydWUKICAgICAgczNmb3JjZXBhdGhzdHlsZTogdHJ1ZQogICAgdHlwZTogczMKYXBpOgogIHByb21ldGhldXNfaHR0cF9wcmVmaXg6IC9wcm9tZXRoZXVzCiAgcmVzcG9uc2VfY29tcHJlc3Npb25fZW5hYmxlZDogdHJ1ZQphdXRoX2VuYWJsZWQ6IHRydWUKYmxvY2tzX3N0b3JhZ2U6CiAgYmFja2VuZDogczMKICBidWNrZXRfc3RvcmU6CiAgICBidWNrZXRfaW5kZXg6CiAgICAgIGVuYWJsZWQ6IHRydWUKICAgIGlnbm9yZV9kZWxldGlvbl9tYXJrX2RlbGF5OiAxaAogICAgc3luY19kaXI6IC9kYXRhCiAgczM6CiAgICBidWNrZXRfbmFtZTogY29ydGV4CiAgICBlbmRwb2ludDogbWluaW86OTAwMAogICAgaW5zZWN1cmU6IHRydWUKICB0c2RiOgogICAgY2xvc2VfaWRsZV90c2RiX3RpbWVvdXQ6IDM2NW0KICAgIGRpcjogL2RhdGEKICAgIGZsdXNoX2Jsb2Nrc19vbl9zaHV0ZG93bjogdHJ1ZQogICAgcmV0ZW50aW9uX3BlcmlvZDogMzY1bQogICAgd2FsX2NvbXByZXNzaW9uX2VuYWJsZWQ6IHRydWUKY2h1bmtfc3RvcmU6CiAgY2h1bmtfY2FjaGVfY29uZmlnOgogICAgbWVtY2FjaGVkOgogICAgICBleHBpcmF0aW9uOiAxaAogICAgbWVtY2FjaGVkX2NsaWVudDoKICAgICAgdGltZW91dDogMXMKY29tcGFjdG9yOgogIGJsb2NrX2RlbGV0aW9uX21hcmtzX21pZ3JhdGlvbl9lbmFibGVkOiBmYWxzZQogIGNvbXBhY3Rpb25faW50ZXJ2YWw6IDMwbQogIGRhdGFfZGlyOiAvZGF0YS9jb3J0ZXgvY29tcGFjdG9yCiAgc2hhcmRpbmdfZW5hYmxlZDogdHJ1ZQogIHNoYXJkaW5nX3Jpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdApkaXN0cmlidXRvcjoKICBoYV90cmFja2VyOgogICAgZW5hYmxlX2hhX3RyYWNrZXI6IHRydWUKICAgIGt2c3RvcmU6CiAgICAgIGNvbnN1bDoKICAgICAgICBob3N0OiBjb25zdWwtY29uc3VsLXNlcnZlcjo4NTAwCiAgICAgIHN0b3JlOiBjb25zdWwKICBwb29sOgogICAgaGVhbHRoX2NoZWNrX2luZ2VzdGVyczogdHJ1ZQogIHJpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdAogIHNoYXJkX2J5X2FsbF9sYWJlbHM6IHRydWUKZnJvbnRlbmQ6CiAgbG9nX3F1ZXJpZXNfbG9uZ2VyX3RoYW46IDEwcwppbmdlc3RlcjoKICBsaWZlY3ljbGVyOgogICAgZmluYWxfc2xlZXA6IDBzCiAgICBqb2luX2FmdGVyOiAwcwogICAgbnVtX3Rva2VuczogNTEyCiAgICByaW5nOgogICAgICBrdnN0b3JlOgogICAgICAgIGNvbnN1bDoKICAgICAgICAgIGNvbnNpc3RlbnRfcmVhZHM6IHRydWUKICAgICAgICAgIGhvc3Q6IGNvbnN1bDo4NTAwCiAgICAgICAgICBodHRwX2NsaWVudF90aW1lb3V0OiAyMHMKICAgICAgICBwcmVmaXg6IGNvbGxlY3RvcnMvCiAgICAgICAgc3RvcmU6IG1lbWJlcmxpc3QKICAgICAgcmVwbGljYXRpb25fZmFjdG9yOiAzCiAgbWF4X3RyYW5zZmVyX3JldHJpZXM6IDAKaW5nZXN0ZXJfY2xpZW50OgogIGdycGNfY2xpZW50X2NvbmZpZzoKICAgIG1heF9yZWN2X21zZ19zaXplOiAxMDQ4NTc2MDAKICAgIG1heF9zZW5kX21zZ19zaXplOiAxMDQ4NTc2MDAKbGltaXRzOgogIGFjY2VwdF9oYV9zYW1wbGVzOiB0cnVlCiAgZW5mb3JjZV9tZXRyaWNfbmFtZTogZmFsc2UKICBtYXhfbGFiZWxfbmFtZXNfcGVyX3NlcmllczogNDAKICBtYXhfcXVlcnlfbG9va2JhY2s6IDE2OGgKICByZWplY3Rfb2xkX3NhbXBsZXM6IHRydWUKICByZWplY3Rfb2xkX3NhbXBsZXNfbWF4X2FnZTogMTY4aAptZW1iZXJsaXN0OgogIGJpbmRfcG9ydDogNzk0NgogIGpvaW5fbWVtYmVyczoKICAtIGNvcnRleC1pbmdlc3Rlci1oZWFkbGVzcwpxdWVyaWVyOgogIGFjdGl2ZV9xdWVyeV90cmFja2VyX2RpcjogL2RhdGEvY29ydGV4L3F1ZXJpZXIKICBxdWVyeV9pbmdlc3RlcnNfd2l0aGluOiAzNjVtCiAgcXVlcnlfc3RvcmVfYWZ0ZXI6IDM2MG0KICBzdG9yZV9nYXRld2F5X2FkZHJlc3NlczogfC0KICAgIApxdWVyeV9yYW5nZToKICBhbGlnbl9xdWVyaWVzX3dpdGhfc3RlcDogdHJ1ZQogIGNhY2hlX3Jlc3VsdHM6IHRydWUKICByZXN1bHRzX2NhY2hlOgogICAgY2FjaGU6CiAgICAgIG1lbWNhY2hlZDoKICAgICAgICBleHBpcmF0aW9uOiAxaAogICAgICBtZW1jYWNoZWRfY2xpZW50OgogICAgICAgIHRpbWVvdXQ6IDFzCiAgc3BsaXRfcXVlcmllc19ieV9pbnRlcnZhbDogMjRoCnJ1bGVyOgogIGFsZXJ0bWFuYWdlcl91cmw6IGh0dHA6Ly9faHR0cC1tZXRyaWNzLl90Y3AuY29ydGV4LWFsZXJ0bWFuYWdlci1oZWFkbGVzcy1ra3AvYXBpL3Byb20vYWxlcnRtYW5hZ2VyLwogIGVuYWJsZV9hbGVydG1hbmFnZXJfZGlzY292ZXJ5OiB0cnVlCiAgZW5hYmxlX2FwaTogdHJ1ZQogIHJpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdAogIHN0b3JhZ2U6CiAgICBzMzoKICAgICAgYnVja2V0bmFtZXM6IGNvcnRleC1ydWxlcgogICAgICBlbmRwb2ludDogbWluaW86OTAwMAogICAgICBpbnNlY3VyZTogdHJ1ZQogICAgICBzM2ZvcmNlcGF0aHN0eWxlOiB0cnVlCiAgICB0eXBlOiBzMwpydW50aW1lX2NvbmZpZzoKICBmaWxlOiAvZXRjL2NvcnRleC1ydW50aW1lLWNmZy9ydW50aW1lLWNvbmZpZy55YW1sCiAgcGVyaW9kOiAxMHMKc2NoZW1hOgogIGNvbmZpZ3M6CiAgLSBjaHVua3M6CiAgICAgIHBlcmlvZDogMTY4aAogICAgICBwcmVmaXg6IGNodW5rc18KICAgIGZyb206ICIyMDIwLTExLTAxIgogICAgaW5kZXg6CiAgICAgIHBlcmlvZDogMTY4aAogICAgICBwcmVmaXg6IGluZGV4XwogICAgb2JqZWN0X3N0b3JlOiBjYXNzYW5kcmEKICAgIHNjaGVtYTogdjEwCiAgICBzdG9yZTogY2Fzc2FuZHJhCnNlcnZlcjoKICBncnBjX2xpc3Rlbl9wb3J0OiA5MDk1CiAgZ3JwY19zZXJ2ZXJfbWF4X2NvbmN1cnJlbnRfc3RyZWFtczogMTAwMAogIGdycGNfc2VydmVyX21heF9yZWN2X21zZ19zaXplOiAxMDQ4NTc2MDAKICBncnBjX3NlcnZlcl9tYXhfc2VuZF9tc2dfc2l6ZTogMTA0ODU3NjAwCiAgaHR0cF9saXN0ZW5fcG9ydDogODA4MApzdG9yYWdlOgogIGF6dXJlOiB7fQogIGNhc3NhbmRyYToKICAgIGF1dGg6IHRydWUKICAgIGtleXNwYWNlOiBjb3J0ZXgKICBlbmdpbmU6IGJsb2NrcwogIGluZGV4X3F1ZXJpZXNfY2FjaGVfY29uZmlnOgogICAgbWVtY2FjaGVkOgogICAgICBleHBpcmF0aW9uOiAxaAogICAgbWVtY2FjaGVkX2NsaWVudDoKICAgICAgdGltZW91dDogMXMKc3RvcmVfZ2F0ZXdheToKICBzaGFyZGluZ19lbmFibGVkOiB0cnVlCiAgc2hhcmRpbmdfcmluZzoKICAgIGt2c3RvcmU6CiAgICAgIHN0b3JlOiBtZW1iZXJsaXN0CiAgICByZXBsaWNhdGlvbl9mYWN0b3I6IDIKdGFibGVfbWFuYWdlcjoKICByZXRlbnRpb25fZGVsZXRlc19lbmFibGVkOiBmYWxzZQogIHJldGVudGlvbl9wZXJpb2Q6IDBz
 ---
 # Source: cortex/charts/cortex/templates/alertmanager/alertmanager-svc-headless.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-alertmanager-headless
+  name: release-name-cortex-alertmanager-headless
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
@@ -195,19 +179,19 @@ spec:
       targetPort: cluster
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: alertmanager
 ---
 # Source: cortex/charts/cortex/templates/alertmanager/alertmanager-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-alertmanager
+  name: release-name-cortex-alertmanager
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
@@ -222,19 +206,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: alertmanager
 ---
 # Source: cortex/charts/cortex/templates/compactor/compactor-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-compactor
+  name: release-name-cortex-compactor
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: compactor
@@ -249,19 +233,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: compactor
 ---
 # Source: cortex/charts/cortex/templates/distributor/distributor-svc-headless.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-distributor-headless
+  name: release-name-cortex-distributor-headless
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
@@ -278,19 +262,19 @@ spec:
       targetPort: grpc
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: distributor
 ---
 # Source: cortex/charts/cortex/templates/distributor/distributor-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-distributor
+  name: release-name-cortex-distributor
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
@@ -305,19 +289,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: distributor
 ---
 # Source: cortex/charts/cortex/templates/ingester/ingester-svc-headless.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-ingester-headless
+  name: release-name-cortex-ingester-headless
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
@@ -333,19 +317,19 @@ spec:
       targetPort: grpc
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: ingester
 ---
 # Source: cortex/charts/cortex/templates/ingester/ingester-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-ingester
+  name: release-name-cortex-ingester
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
@@ -360,19 +344,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: ingester
 ---
 # Source: cortex/charts/cortex/templates/querier/querier-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-querier
+  name: release-name-cortex-querier
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: querier
@@ -387,19 +371,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: querier
 ---
 # Source: cortex/charts/cortex/templates/query-frontend/query-frontend-svc-headless.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-query-frontend-headless
+  name: release-name-cortex-query-frontend-headless
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
@@ -416,19 +400,19 @@ spec:
       targetPort: grpc
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: query-frontend
 ---
 # Source: cortex/charts/cortex/templates/query-frontend/query-frontend-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-query-frontend
+  name: release-name-cortex-query-frontend
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
@@ -443,19 +427,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: query-frontend
 ---
 # Source: cortex/charts/cortex/templates/ruler/ruler-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-ruler
+  name: release-name-cortex-ruler
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ruler
@@ -470,19 +454,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: ruler
 ---
 # Source: cortex/charts/cortex/templates/store-gateway/store-gateway-svc-headless.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-store-gateway-headless
+  name: release-name-cortex-store-gateway-headless
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: store-gateway
@@ -498,19 +482,19 @@ spec:
       targetPort: grpc
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: store-gateway
 ---
 # Source: cortex/charts/cortex/templates/store-gateway/store-gateway-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-store-gateway
+  name: release-name-cortex-store-gateway
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: store-gateway
@@ -525,19 +509,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: store-gateway
 ---
 # Source: cortex/charts/cortex/templates/svc-memberlist-headless.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-memberlist
+  name: release-name-cortex-memberlist
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -550,19 +534,19 @@ spec:
       targetPort: gossip
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/part-of: memberlist
 ---
 # Source: cortex/charts/memcached-blocks-index/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-memcached-blocks-index
+  name: release-name-memcached-blocks-index
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-index
     helm.sh/chart: memcached-blocks-index-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -574,18 +558,18 @@ spec:
       nodePort: null
   selector:
     app.kubernetes.io/name: memcached-blocks-index
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
 ---
 # Source: cortex/charts/memcached-blocks-metadata/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-memcached-blocks-metadata
+  name: release-name-memcached-blocks-metadata
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-metadata
     helm.sh/chart: memcached-blocks-metadata-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -597,18 +581,18 @@ spec:
       nodePort: null
   selector:
     app.kubernetes.io/name: memcached-blocks-metadata
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
 ---
 # Source: cortex/charts/memcached-blocks/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-memcached-blocks
+  name: release-name-memcached-blocks
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks
     helm.sh/chart: memcached-blocks-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -620,18 +604,42 @@ spec:
       nodePort: null
   selector:
     app.kubernetes.io/name: memcached-blocks
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/templates/cortex-alertmanager-headless-kkp.yaml
+# This is a KKP-specific headless alertmanager service, used to work around
+# the Cortex helm chart bug in chart versions below v1.0.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: cortex-alertmanager-headless-kkp
+spec:
+  clusterIP: None
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: http-metrics
+    port: 8080
+    protocol: TCP
+    targetPort: http-metrics
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/instance: cortex
+    app.kubernetes.io/name: cortex
+  sessionAffinity: None
+  type: ClusterIP
 ---
 # Source: cortex/charts/cortex/templates/distributor/distributor-dep.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-distributor
+  name: release-name-cortex-distributor
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
@@ -643,7 +651,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: distributor
   strategy:
     rollingUpdate:
@@ -655,17 +663,17 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 4d41f4fdcd8252f3835d781cef638034534fd0b171af5c6e1b9d92a528fe3deb
+        checksum/config: eb6475ca7ae0982a5dccdd2f095c20e91e30975432d457726ed9f4f1301617fa
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -734,10 +742,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         - configMap:
             name: cortex-runtime-config
           name: cortex-runtime-config
@@ -748,12 +756,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-querier
+  name: release-name-cortex-querier
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: querier
@@ -764,7 +772,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: querier
   strategy:
     rollingUpdate:
@@ -776,16 +784,16 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: querier
       annotations:
-        checksum/config: 4d41f4fdcd8252f3835d781cef638034534fd0b171af5c6e1b9d92a528fe3deb
+        checksum/config: eb6475ca7ae0982a5dccdd2f095c20e91e30975432d457726ed9f4f1301617fa
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -795,14 +803,14 @@ spec:
           args:
             - "-target=querier"
             - "-config.file=/etc/cortex/cortex.yaml"
-            - "-querier.frontend-address=RELEASE-NAME-cortex-query-frontend-headless.default.svc.cluster.local:9095"
+            - "-querier.frontend-address=release-name-cortex-query-frontend-headless.default.svc.cluster.local:9095"
             
             - "-blocks-storage.bucket-store.index-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks-index.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+release-name-memcached-blocks-index.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.chunks-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+release-name-memcached-blocks.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.metadata-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks-metadata.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+release-name-memcached-blocks-metadata.default.svc.cluster.local:11211"
             - "-blocks-storage.s3.access-key-id=$(ACCESS_KEY)"
             - "-blocks-storage.s3.secret-access-key=$(SECRET_KEY)"
           volumeMounts:
@@ -869,10 +877,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         - configMap:
             name: cortex-runtime-config
           name: cortex-runtime-config
@@ -883,12 +891,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-query-frontend
+  name: release-name-cortex-query-frontend
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
@@ -899,7 +907,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: query-frontend
   strategy:
     rollingUpdate:
@@ -911,16 +919,16 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:
-        checksum/config: 4d41f4fdcd8252f3835d781cef638034534fd0b171af5c6e1b9d92a528fe3deb
+        checksum/config: eb6475ca7ae0982a5dccdd2f095c20e91e30975432d457726ed9f4f1301617fa
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -985,10 +993,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         - configMap:
             name: cortex-runtime-config
           name: cortex-runtime-config
@@ -997,12 +1005,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-ruler
+  name: release-name-cortex-ruler
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ruler
@@ -1014,7 +1022,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
@@ -1026,17 +1034,17 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ruler
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 4d41f4fdcd8252f3835d781cef638034534fd0b171af5c6e1b9d92a528fe3deb
+        checksum/config: eb6475ca7ae0982a5dccdd2f095c20e91e30975432d457726ed9f4f1301617fa
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -1046,14 +1054,13 @@ spec:
           args:
             - "-target=ruler"
             - "-config.file=/etc/cortex/cortex.yaml"
-            - "-ruler.alertmanager-url=http://_http-metrics._tcp.cortex-alertmanager-headless/api/prom/alertmanager/"
             
             - "-blocks-storage.bucket-store.index-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks-index.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+release-name-memcached-blocks-index.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.chunks-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+release-name-memcached-blocks.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.metadata-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks-metadata.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+release-name-memcached-blocks-metadata.default.svc.cluster.local:11211"
             - "-ruler.storage.s3.access-key-id=$(ACCESS_KEY)"
             - "-ruler.storage.s3.secret-access-key=$(SECRET_KEY)"
           volumeMounts:
@@ -1115,10 +1122,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         - name: tmp
           emptyDir: {}
         - configMap:
@@ -1131,25 +1138,25 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-memcached-blocks-index
+  name: release-name-memcached-blocks-index
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-index
     helm.sh/chart: memcached-blocks-index-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: memcached-blocks-index
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
   replicas: 1
   template:
     metadata:
       labels:
         app.kubernetes.io/name: memcached-blocks-index
         helm.sh/chart: memcached-blocks-index-5.15.4
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
     spec:
       
@@ -1162,7 +1169,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: memcached-blocks-index
-                    app.kubernetes.io/instance: RELEASE-NAME
+                    app.kubernetes.io/instance: release-name
                 namespaces:
                   - "default"
                 topologyKey: kubernetes.io/hostname
@@ -1172,7 +1179,7 @@ spec:
       securityContext:
         fsGroup: 1001
         runAsUser: 1001
-      serviceAccountName: RELEASE-NAME-memcached-blocks-index
+      serviceAccountName: release-name-memcached-blocks-index
       containers:
         - name: memcached
           image: docker.io/bitnami/memcached:1.6.12-debian-10-r0
@@ -1215,25 +1222,25 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-memcached-blocks-metadata
+  name: release-name-memcached-blocks-metadata
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-metadata
     helm.sh/chart: memcached-blocks-metadata-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: memcached-blocks-metadata
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
   replicas: 1
   template:
     metadata:
       labels:
         app.kubernetes.io/name: memcached-blocks-metadata
         helm.sh/chart: memcached-blocks-metadata-5.15.4
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
     spec:
       
@@ -1246,7 +1253,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: memcached-blocks-metadata
-                    app.kubernetes.io/instance: RELEASE-NAME
+                    app.kubernetes.io/instance: release-name
                 namespaces:
                   - "default"
                 topologyKey: kubernetes.io/hostname
@@ -1256,7 +1263,7 @@ spec:
       securityContext:
         fsGroup: 1001
         runAsUser: 1001
-      serviceAccountName: RELEASE-NAME-memcached-blocks-metadata
+      serviceAccountName: release-name-memcached-blocks-metadata
       containers:
         - name: memcached
           image: docker.io/bitnami/memcached:1.6.12-debian-10-r0
@@ -1299,25 +1306,25 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-memcached-blocks
+  name: release-name-memcached-blocks
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks
     helm.sh/chart: memcached-blocks-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: memcached-blocks
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
   replicas: 1
   template:
     metadata:
       labels:
         app.kubernetes.io/name: memcached-blocks
         helm.sh/chart: memcached-blocks-5.15.4
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
     spec:
       
@@ -1330,7 +1337,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: memcached-blocks
-                    app.kubernetes.io/instance: RELEASE-NAME
+                    app.kubernetes.io/instance: release-name
                 namespaces:
                   - "default"
                 topologyKey: kubernetes.io/hostname
@@ -1340,7 +1347,7 @@ spec:
       securityContext:
         fsGroup: 1001
         runAsUser: 1001
-      serviceAccountName: RELEASE-NAME-memcached-blocks
+      serviceAccountName: release-name-memcached-blocks
       containers:
         - name: memcached
           image: docker.io/bitnami/memcached:1.6.12-debian-10-r0
@@ -1383,12 +1390,12 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: RELEASE-NAME-cortex-alertmanager
+  name: release-name-cortex-alertmanager
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
@@ -1400,11 +1407,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: alertmanager
   updateStrategy:
     type: RollingUpdate
-  serviceName: RELEASE-NAME-cortex-alertmanager-headless
+  serviceName: release-name-cortex-alertmanager-headless
   volumeClaimTemplates:
     - metadata:
         name: storage
@@ -1421,17 +1428,17 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 4d41f4fdcd8252f3835d781cef638034534fd0b171af5c6e1b9d92a528fe3deb
+        checksum/config: eb6475ca7ae0982a5dccdd2f095c20e91e30975432d457726ed9f4f1301617fa
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       nodeSelector:
@@ -1454,10 +1461,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         
         - configMap:
             name: cortex-runtime-config
@@ -1469,8 +1476,8 @@ spec:
           args:
             - "-target=alertmanager"
             - "-config.file=/etc/cortex/cortex.yaml"
-            - -alertmanager.cluster.peers=RELEASE-NAME-cortex-alertmanager-0.RELEASE-NAME-cortex-alertmanager-headless.default.svc.cluster.local:9094
-            - -alertmanager.cluster.peers=RELEASE-NAME-cortex-alertmanager-1.RELEASE-NAME-cortex-alertmanager-headless.default.svc.cluster.local:9094
+            - -alertmanager.cluster.peers=release-name-cortex-alertmanager-0.release-name-cortex-alertmanager-headless.default.svc.cluster.local:9094
+            - -alertmanager.cluster.peers=release-name-cortex-alertmanager-1.release-name-cortex-alertmanager-headless.default.svc.cluster.local:9094
             - "-alertmanager.storage.s3.access-key-id=$(ACCESS_KEY)"
             - "-alertmanager.storage.s3.secret-access-key=$(SECRET_KEY)"
           volumeMounts:
@@ -1528,12 +1535,12 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: RELEASE-NAME-cortex-compactor
+  name: release-name-cortex-compactor
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: compactor
@@ -1545,11 +1552,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: compactor
   updateStrategy:
     type: RollingUpdate
-  serviceName: RELEASE-NAME-cortex-compactor
+  serviceName: release-name-cortex-compactor
   volumeClaimTemplates:
     - metadata:
         name: storage
@@ -1566,17 +1573,17 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 4d41f4fdcd8252f3835d781cef638034534fd0b171af5c6e1b9d92a528fe3deb
+        checksum/config: eb6475ca7ae0982a5dccdd2f095c20e91e30975432d457726ed9f4f1301617fa
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       nodeSelector:
@@ -1599,10 +1606,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         
         - configMap:
             name: cortex-runtime-config
@@ -1616,11 +1623,11 @@ spec:
             - "-config.file=/etc/cortex/cortex.yaml"
             
             - "-blocks-storage.bucket-store.index-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks-index.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+release-name-memcached-blocks-index.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.chunks-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+release-name-memcached-blocks.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.metadata-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks-metadata.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+release-name-memcached-blocks-metadata.default.svc.cluster.local:11211"
           volumeMounts:
             
             - mountPath: /etc/cortex-runtime-cfg
@@ -1665,12 +1672,12 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: RELEASE-NAME-cortex-ingester
+  name: release-name-cortex-ingester
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
@@ -1682,11 +1689,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: ingester
   updateStrategy:
     type: RollingUpdate          
-  serviceName: RELEASE-NAME-cortex-ingester-headless
+  serviceName: release-name-cortex-ingester-headless
   volumeClaimTemplates:
     - metadata:
         name: storage
@@ -1703,17 +1710,17 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 4d41f4fdcd8252f3835d781cef638034534fd0b171af5c6e1b9d92a528fe3deb
+        checksum/config: eb6475ca7ae0982a5dccdd2f095c20e91e30975432d457726ed9f4f1301617fa
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       nodeSelector:
@@ -1736,10 +1743,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         
         - configMap:
             name: cortex-runtime-config
@@ -1753,11 +1760,11 @@ spec:
             - "-config.file=/etc/cortex/cortex.yaml"
             
             - "-blocks-storage.bucket-store.index-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks-index.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+release-name-memcached-blocks-index.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.chunks-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+release-name-memcached-blocks.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.metadata-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks-metadata.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+release-name-memcached-blocks-metadata.default.svc.cluster.local:11211"
             - "-blocks-storage.s3.access-key-id=$(ACCESS_KEY)"
             - "-blocks-storage.s3.secret-access-key=$(SECRET_KEY)"
           volumeMounts:
@@ -1822,12 +1829,12 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: RELEASE-NAME-cortex-store-gateway
+  name: release-name-cortex-store-gateway
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: store-gateway
@@ -1839,11 +1846,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: store-gateway
   updateStrategy:
     type: RollingUpdate
-  serviceName: RELEASE-NAME-cortex-store-gateway-headless
+  serviceName: release-name-cortex-store-gateway-headless
   volumeClaimTemplates:
     - metadata:
         name: storage
@@ -1860,17 +1867,17 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 4d41f4fdcd8252f3835d781cef638034534fd0b171af5c6e1b9d92a528fe3deb
+        checksum/config: eb6475ca7ae0982a5dccdd2f095c20e91e30975432d457726ed9f4f1301617fa
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       nodeSelector:
@@ -1893,10 +1900,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         
         - configMap:
             name: cortex-runtime-config
@@ -1910,11 +1917,11 @@ spec:
             - "-config.file=/etc/cortex/cortex.yaml"
             
             - "-blocks-storage.bucket-store.index-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks-index.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+release-name-memcached-blocks-index.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.chunks-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+release-name-memcached-blocks.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.metadata-cache.backend=memcached"
-            - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+RELEASE-NAME-memcached-blocks-metadata.default.svc.cluster.local:11211"
+            - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+release-name-memcached-blocks-metadata.default.svc.cluster.local:11211"
             - "-blocks-storage.s3.access-key-id=$(ACCESS_KEY)"
             - "-blocks-storage.s3.secret-access-key=$(SECRET_KEY)"
           volumeMounts:

--- a/charts/cortex/test/default.yaml.out
+++ b/charts/cortex/test/default.yaml.out
@@ -3,12 +3,12 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: RELEASE-NAME-cortex-distributor
+  name: release-name-cortex-distributor
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: distributor
   maxUnavailable: 1
 ---
@@ -24,12 +24,12 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: RELEASE-NAME-cortex-ingester
+  name: release-name-cortex-ingester
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
@@ -37,7 +37,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: ingester
   maxUnavailable: 1
 ---
@@ -45,12 +45,12 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: RELEASE-NAME-cortex-nginx
+  name: release-name-cortex-nginx
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: nginx
@@ -58,7 +58,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: nginx
   maxUnavailable: 1
 ---
@@ -66,12 +66,12 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: RELEASE-NAME-cortex-querier
+  name: release-name-cortex-querier
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: querier
@@ -79,7 +79,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: querier
   maxUnavailable: 1
 ---
@@ -87,12 +87,12 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: RELEASE-NAME-cortex-query-frontend
+  name: release-name-cortex-query-frontend
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
@@ -100,7 +100,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: query-frontend
   maxUnavailable: 1
 ---
@@ -108,12 +108,12 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: RELEASE-NAME-cortex
+  name: release-name-cortex
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
@@ -125,12 +125,12 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
-  name: RELEASE-NAME-memcached-blocks-index
+  name: release-name-memcached-blocks-index
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-index
     helm.sh/chart: memcached-blocks-index-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: cortex/charts/memcached-blocks-metadata/templates/serviceaccount.yaml
@@ -138,12 +138,12 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
-  name: RELEASE-NAME-memcached-blocks-metadata
+  name: release-name-memcached-blocks-metadata
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-metadata
     helm.sh/chart: memcached-blocks-metadata-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: cortex/charts/memcached-blocks/templates/serviceaccount.yaml
@@ -151,24 +151,24 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
-  name: RELEASE-NAME-memcached-blocks
+  name: release-name-memcached-blocks
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks
     helm.sh/chart: memcached-blocks-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: cortex/charts/cortex/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: RELEASE-NAME-cortex
+  name: release-name-cortex
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
 data:
@@ -178,12 +178,12 @@ data:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: RELEASE-NAME-cortex-nginx
+  name: release-name-cortex-nginx
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: nginx
@@ -230,61 +230,61 @@ data:
 
         # Distributor Config
         location = /ring {
-          proxy_pass      http://RELEASE-NAME-cortex-distributor.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-distributor.default.svc.cluster.local:8080$request_uri;
         }
 
         location = /all_user_stats {
-          proxy_pass      http://RELEASE-NAME-cortex-distributor.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-distributor.default.svc.cluster.local:8080$request_uri;
         }
 
         location = /api/prom/push {
-          proxy_pass      http://RELEASE-NAME-cortex-distributor.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-distributor.default.svc.cluster.local:8080$request_uri;
         }
 
         ## New Remote write API. Ref: https://cortexmetrics.io/docs/api/#remote-write
         location = /api/v1/push {
-          proxy_pass      http://RELEASE-NAME-cortex-distributor.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-distributor.default.svc.cluster.local:8080$request_uri;
         }
 
         # Alertmanager Config
         location ~ /api/prom/alertmanager/.* {
-          proxy_pass      http://RELEASE-NAME-cortex-alertmanager.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-alertmanager.default.svc.cluster.local:8080$request_uri;
         }
 
         location ~ /api/v1/alerts {
-          proxy_pass      http://RELEASE-NAME-cortex-alertmanager.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-alertmanager.default.svc.cluster.local:8080$request_uri;
         }
 
         location ~ /multitenant_alertmanager/status {
-          proxy_pass      http://RELEASE-NAME-cortex-alertmanager.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-alertmanager.default.svc.cluster.local:8080$request_uri;
         }
 
         # Ruler Config
         location ~ /api/v1/rules {
-          proxy_pass      http://RELEASE-NAME-cortex-ruler.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-ruler.default.svc.cluster.local:8080$request_uri;
         }
 
         location ~ /ruler/ring {
-          proxy_pass      http://RELEASE-NAME-cortex-ruler.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-ruler.default.svc.cluster.local:8080$request_uri;
         }
 
         # Config Config
         location ~ /api/prom/configs/.* {
-          proxy_pass      http://RELEASE-NAME-cortex-configs.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-configs.default.svc.cluster.local:8080$request_uri;
         }
 
         # Query Config
         location ~ /api/prom/.* {
-          proxy_pass      http://RELEASE-NAME-cortex-query-frontend.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-query-frontend.default.svc.cluster.local:8080$request_uri;
         }
 
         ## New Query frontend APIs as per https://cortexmetrics.io/docs/api/#querier--query-frontend
         location ~ ^/prometheus/api/v1/(read|metadata|labels|series|query_range|query) {
-          proxy_pass      http://RELEASE-NAME-cortex-query-frontend.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-query-frontend.default.svc.cluster.local:8080$request_uri;
         }
 
         location ~ /prometheus/api/v1/label/.* {
-          proxy_pass      http://RELEASE-NAME-cortex-query-frontend.default.svc.cluster.local:8080$request_uri;
+          proxy_pass      http://release-name-cortex-query-frontend.default.svc.cluster.local:8080$request_uri;
         }
       }
     }
@@ -293,12 +293,12 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: RELEASE-NAME-cortex-runtime-config
+  name: release-name-cortex-runtime-config
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
 data:
@@ -309,12 +309,12 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-alertmanager
+  name: release-name-cortex-alertmanager
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
@@ -329,19 +329,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: alertmanager
 ---
 # Source: cortex/charts/cortex/templates/distributor/distributor-svc-headless.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-distributor-headless
+  name: release-name-cortex-distributor-headless
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
@@ -358,19 +358,19 @@ spec:
       targetPort: grpc
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: distributor
 ---
 # Source: cortex/charts/cortex/templates/distributor/distributor-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-distributor
+  name: release-name-cortex-distributor
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
@@ -385,19 +385,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: distributor
 ---
 # Source: cortex/charts/cortex/templates/ingester/ingester-svc-headless.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-ingester-headless
+  name: release-name-cortex-ingester-headless
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
@@ -413,19 +413,19 @@ spec:
       targetPort: grpc
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: ingester
 ---
 # Source: cortex/charts/cortex/templates/ingester/ingester-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-ingester
+  name: release-name-cortex-ingester
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
@@ -440,19 +440,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: ingester
 ---
 # Source: cortex/charts/cortex/templates/nginx/nginx-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-nginx
+  name: release-name-cortex-nginx
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: nginx
@@ -467,19 +467,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: nginx
 ---
 # Source: cortex/charts/cortex/templates/querier/querier-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-querier
+  name: release-name-cortex-querier
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: querier
@@ -494,19 +494,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: querier
 ---
 # Source: cortex/charts/cortex/templates/query-frontend/query-frontend-svc-headless.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-query-frontend-headless
+  name: release-name-cortex-query-frontend-headless
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
@@ -523,19 +523,19 @@ spec:
       targetPort: grpc
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: query-frontend
 ---
 # Source: cortex/charts/cortex/templates/query-frontend/query-frontend-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-query-frontend
+  name: release-name-cortex-query-frontend
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
@@ -550,19 +550,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: query-frontend
 ---
 # Source: cortex/charts/cortex/templates/ruler/ruler-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-ruler
+  name: release-name-cortex-ruler
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ruler
@@ -577,19 +577,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: ruler
 ---
 # Source: cortex/charts/cortex/templates/svc-memberlist-headless.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-memberlist
+  name: release-name-cortex-memberlist
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -602,19 +602,19 @@ spec:
       targetPort: gossip
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/part-of: memberlist
 ---
 # Source: cortex/charts/cortex/templates/table-manager/table-manager-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-cortex-table-manager
+  name: release-name-cortex-table-manager
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: table-manager
@@ -629,19 +629,19 @@ spec:
       targetPort: http-metrics
   selector:
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: table-manager
 ---
 # Source: cortex/charts/memcached-blocks-index/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-memcached-blocks-index
+  name: release-name-memcached-blocks-index
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-index
     helm.sh/chart: memcached-blocks-index-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -653,18 +653,18 @@ spec:
       nodePort: null
   selector:
     app.kubernetes.io/name: memcached-blocks-index
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
 ---
 # Source: cortex/charts/memcached-blocks-metadata/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-memcached-blocks-metadata
+  name: release-name-memcached-blocks-metadata
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-metadata
     helm.sh/chart: memcached-blocks-metadata-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -676,18 +676,18 @@ spec:
       nodePort: null
   selector:
     app.kubernetes.io/name: memcached-blocks-metadata
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
 ---
 # Source: cortex/charts/memcached-blocks/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: RELEASE-NAME-memcached-blocks
+  name: release-name-memcached-blocks
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks
     helm.sh/chart: memcached-blocks-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -699,18 +699,42 @@ spec:
       nodePort: null
   selector:
     app.kubernetes.io/name: memcached-blocks
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/templates/cortex-alertmanager-headless-kkp.yaml
+# This is a KKP-specific headless alertmanager service, used to work around
+# the Cortex helm chart bug in chart versions below v1.0.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: cortex-alertmanager-headless-kkp
+spec:
+  clusterIP: None
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: http-metrics
+    port: 8080
+    protocol: TCP
+    targetPort: http-metrics
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/instance: cortex
+    app.kubernetes.io/name: cortex
+  sessionAffinity: None
+  type: ClusterIP
 ---
 # Source: cortex/charts/cortex/templates/alertmanager/alertmanager-dep.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-alertmanager
+  name: release-name-cortex-alertmanager
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
@@ -722,7 +746,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: alertmanager
   strategy:
     rollingUpdate:
@@ -734,17 +758,17 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: f6b782a352188a744709a7b73eed77399154b2d0fe9c70f57097f2b84922e1d9
+        checksum/config: 46c7a33ac576f66924d71fd31c0ee2d7c31ca76b5745c0e54ad6f38dd8ff95ce
         prometheus.io/port: http-metrics
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -797,10 +821,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         - name: storage
           emptyDir: {}
 ---
@@ -808,12 +832,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-distributor
+  name: release-name-cortex-distributor
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
@@ -825,7 +849,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: distributor
   strategy:
     rollingUpdate:
@@ -837,17 +861,17 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: f6b782a352188a744709a7b73eed77399154b2d0fe9c70f57097f2b84922e1d9
+        checksum/config: 46c7a33ac576f66924d71fd31c0ee2d7c31ca76b5745c0e54ad6f38dd8ff95ce
         prometheus.io/port: http-metrics
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -913,10 +937,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         - name: storage
           emptyDir: {}
 ---
@@ -924,12 +948,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-ingester
+  name: release-name-cortex-ingester
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
@@ -941,7 +965,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: ingester
   strategy:
     rollingUpdate:
@@ -953,17 +977,17 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: f6b782a352188a744709a7b73eed77399154b2d0fe9c70f57097f2b84922e1d9
+        checksum/config: 46c7a33ac576f66924d71fd31c0ee2d7c31ca76b5745c0e54ad6f38dd8ff95ce
         prometheus.io/port: http-metrics
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -1038,10 +1062,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         - name: storage
           emptyDir: {}
 ---
@@ -1049,12 +1073,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-nginx
+  name: release-name-cortex-nginx
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: nginx
@@ -1065,7 +1089,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: nginx
   strategy:
     rollingUpdate:
@@ -1077,16 +1101,16 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: nginx
       annotations:
-        checksum/config: 528c0fa419e90b3c5c711d1a8cb59108dbbad312db59d01b911a5f88503219d8
+        checksum/config: 339df495623736167893ab2e4ef4395e50a0db14b96a3151be5b45a86bd7844d
         prometheus.io/port: http-metrics
         prometheus.io/scrape: ""
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -1128,18 +1152,18 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: RELEASE-NAME-cortex-nginx
+            name: release-name-cortex-nginx
 ---
 # Source: cortex/charts/cortex/templates/querier/querier-dep.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-querier
+  name: release-name-cortex-querier
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: querier
@@ -1150,7 +1174,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: querier
   strategy:
     rollingUpdate:
@@ -1162,16 +1186,16 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: querier
       annotations:
-        checksum/config: f6b782a352188a744709a7b73eed77399154b2d0fe9c70f57097f2b84922e1d9
+        checksum/config: 46c7a33ac576f66924d71fd31c0ee2d7c31ca76b5745c0e54ad6f38dd8ff95ce
         prometheus.io/port: http-metrics
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -1181,7 +1205,7 @@ spec:
           args:
             - "-target=querier"
             - "-config.file=/etc/cortex/cortex.yaml"
-            - "-querier.frontend-address=RELEASE-NAME-cortex-query-frontend-headless.default.svc.cluster.local:9095"
+            - "-querier.frontend-address=release-name-cortex-query-frontend-headless.default.svc.cluster.local:9095"
             
           volumeMounts:
             - name: config
@@ -1233,10 +1257,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         - name: storage
           emptyDir: {}
 ---
@@ -1244,12 +1268,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-query-frontend
+  name: release-name-cortex-query-frontend
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
@@ -1260,7 +1284,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: query-frontend
   strategy:
     rollingUpdate:
@@ -1272,16 +1296,16 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:
-        checksum/config: f6b782a352188a744709a7b73eed77399154b2d0fe9c70f57097f2b84922e1d9
+        checksum/config: 46c7a33ac576f66924d71fd31c0ee2d7c31ca76b5745c0e54ad6f38dd8ff95ce
         prometheus.io/port: http-metrics
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -1342,21 +1366,21 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
 ---
 # Source: cortex/charts/cortex/templates/ruler/ruler-dep.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-ruler
+  name: release-name-cortex-ruler
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ruler
@@ -1368,7 +1392,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: ruler
   strategy:
     rollingUpdate:
@@ -1380,17 +1404,17 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ruler
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: f6b782a352188a744709a7b73eed77399154b2d0fe9c70f57097f2b84922e1d9
+        checksum/config: 46c7a33ac576f66924d71fd31c0ee2d7c31ca76b5745c0e54ad6f38dd8ff95ce
         prometheus.io/port: http-metrics
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -1400,7 +1424,7 @@ spec:
           args:
             - "-target=ruler"
             - "-config.file=/etc/cortex/cortex.yaml"
-            - "-ruler.alertmanager-url=http://RELEASE-NAME-cortex-alertmanager.default.svc.cluster.local:8080/api/prom/alertmanager/"
+            - "-ruler.alertmanager-url=http://release-name-cortex-alertmanager.default.svc.cluster.local:8080/api/prom/alertmanager/"
             
           volumeMounts:
             - name: config
@@ -1447,10 +1471,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         - name: tmp
           emptyDir: {}
         - name: storage
@@ -1460,12 +1484,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-cortex-table-manager
+  name: release-name-cortex-table-manager
   namespace: default
   labels:
     helm.sh/chart: cortex-0.7.0
     app.kubernetes.io/name: cortex
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "v1.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: table-manager
@@ -1476,7 +1500,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: table-manager
   strategy:
     rollingUpdate:
@@ -1488,16 +1512,16 @@ spec:
       labels:
         helm.sh/chart: cortex-0.7.0
         app.kubernetes.io/name: cortex
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "v1.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: table-manager
       annotations:
-        checksum/config: f6b782a352188a744709a7b73eed77399154b2d0fe9c70f57097f2b84922e1d9
+        checksum/config: 46c7a33ac576f66924d71fd31c0ee2d7c31ca76b5745c0e54ad6f38dd8ff95ce
         prometheus.io/port: http-metrics
         prometheus.io/scrape: "true"
     spec:
-      serviceAccountName: RELEASE-NAME-cortex
+      serviceAccountName: release-name-cortex
       initContainers:
         []
       containers:
@@ -1547,10 +1571,10 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: RELEASE-NAME-cortex
+            secretName: release-name-cortex
         - name: runtime-config
           configMap:
-            name: RELEASE-NAME-cortex-runtime-config
+            name: release-name-cortex-runtime-config
         - name: storage
           emptyDir: {}
 ---
@@ -1558,25 +1582,25 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-memcached-blocks-index
+  name: release-name-memcached-blocks-index
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-index
     helm.sh/chart: memcached-blocks-index-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: memcached-blocks-index
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
   replicas: 1
   template:
     metadata:
       labels:
         app.kubernetes.io/name: memcached-blocks-index
         helm.sh/chart: memcached-blocks-index-5.15.4
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
     spec:
       
@@ -1589,7 +1613,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: memcached-blocks-index
-                    app.kubernetes.io/instance: RELEASE-NAME
+                    app.kubernetes.io/instance: release-name
                 namespaces:
                   - "default"
                 topologyKey: kubernetes.io/hostname
@@ -1599,7 +1623,7 @@ spec:
       securityContext:
         fsGroup: 1001
         runAsUser: 1001
-      serviceAccountName: RELEASE-NAME-memcached-blocks-index
+      serviceAccountName: release-name-memcached-blocks-index
       containers:
         - name: memcached
           image: docker.io/bitnami/memcached:1.6.12-debian-10-r0
@@ -1642,25 +1666,25 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-memcached-blocks-metadata
+  name: release-name-memcached-blocks-metadata
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks-metadata
     helm.sh/chart: memcached-blocks-metadata-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: memcached-blocks-metadata
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
   replicas: 1
   template:
     metadata:
       labels:
         app.kubernetes.io/name: memcached-blocks-metadata
         helm.sh/chart: memcached-blocks-metadata-5.15.4
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
     spec:
       
@@ -1673,7 +1697,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: memcached-blocks-metadata
-                    app.kubernetes.io/instance: RELEASE-NAME
+                    app.kubernetes.io/instance: release-name
                 namespaces:
                   - "default"
                 topologyKey: kubernetes.io/hostname
@@ -1683,7 +1707,7 @@ spec:
       securityContext:
         fsGroup: 1001
         runAsUser: 1001
-      serviceAccountName: RELEASE-NAME-memcached-blocks-metadata
+      serviceAccountName: release-name-memcached-blocks-metadata
       containers:
         - name: memcached
           image: docker.io/bitnami/memcached:1.6.12-debian-10-r0
@@ -1726,25 +1750,25 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: RELEASE-NAME-memcached-blocks
+  name: release-name-memcached-blocks
   namespace: default
   labels:
     app.kubernetes.io/name: memcached-blocks
     helm.sh/chart: memcached-blocks-5.15.4
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: memcached-blocks
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
   replicas: 1
   template:
     metadata:
       labels:
         app.kubernetes.io/name: memcached-blocks
         helm.sh/chart: memcached-blocks-5.15.4
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
     spec:
       
@@ -1757,7 +1781,7 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: memcached-blocks
-                    app.kubernetes.io/instance: RELEASE-NAME
+                    app.kubernetes.io/instance: release-name
                 namespaces:
                   - "default"
                 topologyKey: kubernetes.io/hostname
@@ -1767,7 +1791,7 @@ spec:
       securityContext:
         fsGroup: 1001
         runAsUser: 1001
-      serviceAccountName: RELEASE-NAME-memcached-blocks
+      serviceAccountName: release-name-memcached-blocks
       containers:
         - name: memcached
           image: docker.io/bitnami/memcached:1.6.12-debian-10-r0

--- a/config/cortex/values.yaml
+++ b/config/cortex/values.yaml
@@ -257,6 +257,8 @@ cortex:
       file: "/etc/cortex-runtime-cfg/runtime-config.yaml"
     ruler:
       enable_alertmanager_discovery: true
+      # This is a KKP-specific headless alertmanager service, used to work around the Cortex helm chart bug in chart versions below v1.0.0
+      alertmanager_url: http://_http-metrics._tcp.cortex-alertmanager-headless-kkp/api/prom/alertmanager/
       enable_api: true
       ring:
         kvstore:

--- a/config/loki/values.yaml
+++ b/config/loki/values.yaml
@@ -89,7 +89,8 @@ loki-distributed:
           kvstore:
             store: memberlist
         rule_path: /tmp/loki/scratch
-        alertmanager_url: http://_http-metrics._tcp.cortex-alertmanager-headless/api/prom/alertmanager/
+        # This is a KKP-specific headless alertmanager service, used to work around the Cortex helm chart bug in chart versions below v1.0.0
+        alertmanager_url: http://_http-metrics._tcp.cortex-alertmanager-headless-kkp/api/prom/alertmanager/
 
   tableManager:
     enabled: true


### PR DESCRIPTION
Cortex helm chart versions between v0.7.0 and v1.0.0 have a bug in alertmanager headless service definition (reference to a wrong port). This PR adds our own `cortex-alertmanager-headless-kkp` service on top of the Cortex deployment and makes use of it instead of the one provided with the Cortex helm chart.

This can be removed and cleaned up after upgrade to Cortex helm chart v1.0.0+.

Fixes #90 