### PR TITLE
Enable using a single values file for all mla charts

### DIFF
--- a/charts/alertmanager-proxy/templates/authzserver-deployment.yaml
+++ b/charts/alertmanager-proxy/templates/authzserver-deployment.yaml
@@ -20,7 +20,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: alertmanager-authz-server
-  replicas: {{ .Values.alertmanagerAuthzServer.replicas }}
+  replicas: {{ .Values.alertmanagerProxy.authz.replicas }}
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: alertmanager-authz-server
       containers:
         - name: authz-server
-          image: '{{ .Values.alertmanagerAuthzServer.image.repository }}:{{ .Values.alertmanagerAuthzServer.image.tag }}'
+          image: '{{ .Values.alertmanagerProxy.authz.image.repository }}:{{ .Values.alertmanagerProxy.authz.image.tag }}'
           ports:
             - containerPort: 50051
           command:
@@ -44,10 +44,10 @@ spec:
           args:
             - -log-debug=true
           resources:
-{{ toYaml .Values.alertmanagerAuthzServer.resources | indent 12 }}
+{{ toYaml .Values.alertmanagerProxy.authz.resources | indent 12 }}
       nodeSelector:
-{{ toYaml .Values.alertmanagerAuthzServer.nodeSelector | indent 8 }}
+{{ toYaml .Values.alertmanagerProxy.authz.nodeSelector | indent 8 }}
       affinity:
-{{ toYaml .Values.alertmanagerAuthzServer.affinity | indent 8 }}
+{{ toYaml .Values.alertmanagerProxy.authz.affinity | indent 8 }}
       tolerations:
-{{ toYaml .Values.alertmanagerAuthzServer.tolerations | indent 8 }}
+{{ toYaml .Values.alertmanagerProxy.authz.tolerations | indent 8 }}

--- a/charts/alertmanager-proxy/templates/proxy-configmap.yaml
+++ b/charts/alertmanager-proxy/templates/proxy-configmap.yaml
@@ -135,8 +135,8 @@ data:
             - endpoint:
                 address:
                   socket_address:
-                    address: {{ .Values.alertmanagerProxy.backendAddress }}
-                    port_value: {{ .Values.alertmanagerProxy.backendPort }}
+                    address: {{ .Values.alertmanagerProxy.proxy.backendAddress }}
+                    port_value: {{ .Values.alertmanagerProxy.proxy.backendPort }}
 
       - name: ext-authz
         type: STRICT_DNS

--- a/charts/alertmanager-proxy/templates/proxy-deployment.yaml
+++ b/charts/alertmanager-proxy/templates/proxy-deployment.yaml
@@ -20,7 +20,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: alertmanager-proxy
-  replicas: {{ .Values.alertmanagerProxy.replicas }}
+  replicas: {{ .Values.alertmanagerProxy.proxy.replicas }}
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: envoy
-          image: '{{ .Values.alertmanagerProxy.image.repository }}:{{ .Values.alertmanagerProxy.image.tag }}'
+          image: '{{ .Values.alertmanagerProxy.proxy.image.repository }}:{{ .Values.alertmanagerProxy.proxy.image.tag }}'
           ports:
             - containerPort: 8080
               name: proxy
@@ -60,14 +60,14 @@ spec:
             - name:  envoy-config
               mountPath: /etc/envoy
           resources:
-{{ toYaml .Values.alertmanagerProxy.resources | indent 12 }}
+{{ toYaml .Values.alertmanagerProxy.proxy.resources | indent 12 }}
       volumes:
         - name: envoy-config
           configMap:
             name: alertmanager-proxy-config
       nodeSelector:
-{{ toYaml .Values.alertmanagerProxy.nodeSelector | indent 8 }}
+{{ toYaml .Values.alertmanagerProxy.proxy.nodeSelector | indent 8 }}
       affinity:
-{{ toYaml .Values.alertmanagerProxy.affinity | indent 8 }}
+{{ toYaml .Values.alertmanagerProxy.proxy.affinity | indent 8 }}
       tolerations:
-{{ toYaml .Values.alertmanagerProxy.tolerations | indent 8 }}
+{{ toYaml .Values.alertmanagerProxy.proxy.tolerations | indent 8 }}

--- a/charts/alertmanager-proxy/test/default.yaml
+++ b/charts/alertmanager-proxy/test/default.yaml
@@ -1,0 +1,13 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/alertmanager-proxy/test/default.yaml.out
+++ b/charts/alertmanager-proxy/test/default.yaml.out
@@ -1,0 +1,464 @@
+---
+# Source: alertmanager-proxy/templates/authzserver-serviceaccount.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alertmanager-authz-server
+---
+# Source: alertmanager-proxy/templates/proxy-configmap.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-proxy-config
+data:
+  envoy.yaml: |
+    admin:
+      access_log_path: /tmp/admin_access.log
+      address:
+        socket_address:
+          protocol: TCP
+          address: 127.0.0.1
+          port_value: 9901
+      
+    static_resources:
+      listeners:
+
+      ### authorization and path rewiting proxy ###
+      - name: listener_http
+        address:
+          socket_address:
+            protocol: TCP
+            address: 0.0.0.0
+            port_value: 8080
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:  
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: ingress_http
+              access_log:
+              - name: envoy.access_loggers.file
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                  path: /dev/stdout
+              route_config:
+                name: local_route
+                virtual_hosts:
+                - name: local_service
+                  domains: ["*"]
+                  routes:
+
+                  # redirect if the path contains only cluster ID without slash (append slash at the end)
+                  - match:
+                      safe_regex:
+                        google_re2: {}
+                        regex: '^/([[:alnum:]]+)$'
+                    redirect:
+                      regex_rewrite:
+                        pattern:
+                          google_re2: {}
+                          regex: '^/([[:alnum:]]+)$'
+                        substitution: '/\1/'
+
+                  # strip tenant ID from the path
+                  - match:
+                      safe_regex:
+                        google_re2: {}
+                        regex: '^/(.+?)/(.*)'
+                    route:
+                      regex_rewrite:
+                        pattern:
+                          google_re2: {}
+                          regex: '^/(.+?)/(.*)'
+                        substitution: '/api/prom/alertmanager/\2'
+                      cluster: service_backend
+
+              http_filters:
+              - name: envoy.filters.http.ext_authz
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                  transport_api_version: V3
+                  grpc_service:
+                    envoy_grpc:
+                      cluster_name: ext-authz
+                    timeout: 2s
+                  status_on_error:
+                    code: ServiceUnavailable
+              - name: envoy.filters.http.router
+
+      ### limited access to envoy stats and health ###
+      - name: service_stats
+        address:
+          socket_address:
+            protocol: TCP
+            address: 0.0.0.0
+            port_value: 9902
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: service_stats
+              route_config:
+                name: local_route
+                virtual_hosts:
+                - name: stats_backend
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: "/stats"
+                    route:
+                      cluster: service_stats
+                  - match:
+                      prefix: "/ready"
+                    route:
+                      cluster: service_stats
+              http_filters:
+              - name: envoy.filters.http.router
+
+      clusters:
+      - name: service_backend
+        connect_timeout: 2s
+        type: STRICT_DNS
+        dns_lookup_family: V4_ONLY
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: service_backend
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: cortex-alertmanager
+                    port_value: 8080
+
+      - name: ext-authz
+        type: STRICT_DNS
+        connect_timeout: 2s
+        http2_protocol_options: {}
+        load_assignment:
+          cluster_name: ext-authz
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: alertmanager-authz-server
+                        port_value: 50051
+
+      - name: service_stats
+        connect_timeout: 0.1s
+        type: STATIC
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: service_stats
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 9901
+---
+# Source: alertmanager-proxy/templates/authzserver-clusterrole.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alertmanager-authz-server
+rules:
+  - apiGroups:
+      - kubermatic.k8c.io
+    resources:
+      - clusters
+      - users
+      - userprojectbindings
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: alertmanager-proxy/templates/authzserver-clusterrolebinding.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alertmanager-authz-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alertmanager-authz-server
+subjects:
+  - kind: ServiceAccount
+    name: alertmanager-authz-server
+    namespace: default
+---
+# Source: alertmanager-proxy/templates/authzserver-service.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-authz-server
+  labels:
+    app.kubernetes.io/name: alertmanager-authz-server
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 50051
+      targetPort: 50051
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: alertmanager-authz-server
+---
+# Source: alertmanager-proxy/templates/proxy-service.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-proxy
+  labels:
+    app.kubernetes.io/name: alertmanager-proxy
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: alertmanager-proxy
+---
+# Source: alertmanager-proxy/templates/authzserver-deployment.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alertmanager-authz-server
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager-authz-server
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  progressDeadlineSeconds: 600
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alertmanager-authz-server
+    spec:
+      serviceAccountName: alertmanager-authz-server
+      containers:
+        - name: authz-server
+          image: 'quay.io/kubermatic/alertmanager-authorization-server:0.2.0'
+          ports:
+            - containerPort: 50051
+          command:
+            - /alertmanager-authorization-server
+          args:
+            - -log-debug=true
+          resources:
+            limits:
+              cpu: 200m
+              memory: 64Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: alertmanager-authz-server
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      tolerations:
+        []
+---
+# Source: alertmanager-proxy/templates/proxy-deployment.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alertmanager-proxy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager-proxy
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  progressDeadlineSeconds: 600
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      annotations:
+        prometheus.io/metrics_path: /stats/prometheus
+        prometheus.io/port: "9902"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: alertmanager-proxy
+    spec:
+      containers:
+        - name: envoy
+          image: 'envoyproxy/envoy:v1.18.3'
+          ports:
+            - containerPort: 8080
+              name: proxy
+              protocol: TCP
+            - containerPort: 9902
+              name: stats
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: 9902
+              scheme: HTTP
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 1
+          volumeMounts:
+            - name:  envoy-config
+              mountPath: /etc/envoy
+          resources:
+            limits:
+              cpu: 200m
+              memory: 64Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: alertmanager-proxy-config
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: alertmanager-proxy
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      tolerations:
+        []

--- a/charts/alertmanager-proxy/test/test.sh
+++ b/charts/alertmanager-proxy/test/test.sh
@@ -1,0 +1,1 @@
+../../../hack/test-chart-rendering.sh

--- a/charts/alertmanager-proxy/values.yaml
+++ b/charts/alertmanager-proxy/values.yaml
@@ -13,51 +13,52 @@
 # limitations under the License.
 
 alertmanagerProxy:
-  backendAddress: cortex-alertmanager
-  backendPort: 8080
-  image:
-    repository: "envoyproxy/envoy"
-    tag: "v1.18.3"
-  replicas: 1
-  resources:
-    requests:
-      cpu: 50m
-      memory: 32Mi
-    limits:
-      cpu: 200m
-      memory: 64Mi
-  nodeSelector: {}
-  affinity:
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                app.kubernetes.io/name: alertmanager-proxy
-            topologyKey: kubernetes.io/hostname
-          weight: 100
-  tolerations: []
+  proxy:
+    backendAddress: cortex-alertmanager
+    backendPort: 8080
+    image:
+      repository: "envoyproxy/envoy"
+      tag: "v1.18.3"
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
+        cpu: 200m
+        memory: 64Mi
+    nodeSelector: {}
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: alertmanager-proxy
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+    tolerations: []
 
-alertmanagerAuthzServer:
-  image:
-    repository: "quay.io/kubermatic/alertmanager-authorization-server"
-    tag: "0.2.0"
-  replicas: 1
-  resources:
-    requests:
-      cpu: 50m
-      memory: 32Mi
-    limits:
-      cpu: 200m
-      memory: 64Mi
-  nodeSelector: {}
-  affinity:
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                app.kubernetes.io/name: alertmanager-authz-server
-            topologyKey: kubernetes.io/hostname
-          weight: 100
-  tolerations: []
+  authz:
+    image:
+      repository: "quay.io/kubermatic/alertmanager-authorization-server"
+      tag: "0.2.0"
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
+        cpu: 200m
+        memory: 64Mi
+    nodeSelector: {}
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: alertmanager-authz-server
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+    tolerations: []

--- a/charts/mla-secrets/templates/grafana-secret.yaml
+++ b/charts/mla-secrets/templates/grafana-secret.yaml
@@ -1,17 +1,17 @@
-{{- if .Values.grafana.enabled }}
+{{- if .Values.mlaSecrets.grafana.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: grafana
 type: Opaque
 data:
-  admin-user: {{ .Values.grafana.adminUser | b64enc | quote }}
-  {{- if .Values.grafana.adminPassword }}
-  admin-password: {{ .Values.grafana.adminPassword | b64enc | quote }}
+  admin-user: {{ .Values.mlaSecrets.grafana.adminUser | b64enc | quote }}
+  {{- if .Values.mlaSecrets.grafana.adminPassword }}
+  admin-password: {{ .Values.mlaSecrets.grafana.adminPassword | b64enc | quote }}
   {{- else }}
   admin-password: {{ randAlphaNum 40 | b64enc | quote }}
   {{- end }}
-  {{- if and .Values.grafana.ldap.enabled .Values.grafana.ldap.config }}
-  ldap-toml: {{ tpl .Values.grafana.ldap.config $ | b64enc | quote }}
+  {{- if and .Values.mlaSecrets.grafana.ldap.enabled .Values.mlaSecrets.grafana.ldap.config }}
+  ldap-toml: {{ tpl .Values.mlaSecrets.grafana.ldap.config $ | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/mla-secrets/templates/minio-secret.yaml
+++ b/charts/mla-secrets/templates/minio-secret.yaml
@@ -1,27 +1,27 @@
-{{- if .Values.minio.enabled }}
+{{- if .Values.mlaSecrets.minio.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: minio
 type: Opaque
 data:
-  rootUser: {{ if .Values.minio.accessKey }}{{ .Values.minio.accessKey | toString | b64enc | quote }}{{ else }}{{ randAlphaNum 20 | b64enc | quote }}{{ end }}
-  rootPassword: {{ if .Values.minio.secretKey }}{{ .Values.minio.secretKey | toString | b64enc | quote }}{{ else }}{{ randAlphaNum 40 | b64enc | quote }}{{ end }}
-{{- if and .Values.minio.gcsgateway.enabled .Values.minio.gcsgateway.gcsKeyJson }}
-  gcs_key.json: {{ .Values.minio.gcsgateway.gcsKeyJson | toString | b64enc }}
+  rootUser: {{ if .Values.mlaSecrets.minio.accessKey }}{{ .Values.mlaSecrets.minio.accessKey | toString | b64enc | quote }}{{ else }}{{ randAlphaNum 20 | b64enc | quote }}{{ end }}
+  rootPassword: {{ if .Values.mlaSecrets.minio.secretKey }}{{ .Values.mlaSecrets.minio.secretKey | toString | b64enc | quote }}{{ else }}{{ randAlphaNum 40 | b64enc | quote }}{{ end }}
+{{- if and .Values.mlaSecrets.minio.gcsgateway.enabled .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson }}
+  gcs_key.json: {{ .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson | toString | b64enc }}
 {{- end }}
-{{- if .Values.minio.s3gateway.enabled -}}
-{{- if .Values.minio.s3gateway.accessKey }}
-  awsAccessKeyId: {{ .Values.minio.s3gateway.accessKey | toString | b64enc | quote }}
+{{- if .Values.mlaSecrets.minio.s3gateway.enabled -}}
+{{- if .Values.mlaSecrets.minio.s3gateway.accessKey }}
+  awsAccessKeyId: {{ .Values.mlaSecrets.minio.s3gateway.accessKey | toString | b64enc | quote }}
 {{- end }}
-{{- if .Values.minio.s3gateway.secretKey }}
-  awsSecretAccessKey: {{ .Values.minio.s3gateway.secretKey | toString | b64enc | quote }}
+{{- if .Values.mlaSecrets.minio.s3gateway.secretKey }}
+  awsSecretAccessKey: {{ .Values.mlaSecrets.minio.s3gateway.secretKey | toString | b64enc | quote }}
 {{- end }}
 {{- end }}
-{{- if .Values.minio.etcd.clientCert }}
-  etcd_client_cert.pem: {{ .Values.minio.etcd.clientCert | toString | b64enc | quote }}
+{{- if .Values.mlaSecrets.minio.etcd.clientCert }}
+  etcd_client_cert.pem: {{ .Values.mlaSecrets.minio.etcd.clientCert | toString | b64enc | quote }}
 {{- end }}
-{{- if .Values.minio.etcd.clientCertKey }}
-  etcd_client_cert_key.pem: {{ .Values.minio.etcd.clientCertKey | toString | b64enc | quote }}
+{{- if .Values.mlaSecrets.minio.etcd.clientCertKey }}
+  etcd_client_cert_key.pem: {{ .Values.mlaSecrets.minio.etcd.clientCertKey | toString | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/charts/mla-secrets/test/config.yaml
+++ b/charts/mla-secrets/test/config.yaml
@@ -1,0 +1,1 @@
+../../../config/mla-secrets/values.yaml

--- a/charts/mla-secrets/test/config.yaml.out
+++ b/charts/mla-secrets/test/config.yaml.out
@@ -1,0 +1,20 @@
+---
+# Source: mla-secrets/templates/grafana-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana
+type: Opaque
+data:
+  admin-user: "YWRtaW4="
+  admin-password: "aG5DMGRvQ0FxbGtjbmI0Z21ORm5xeUpzRWFpZDE1ajBRWDhwRDhwUQ=="
+---
+# Source: mla-secrets/templates/minio-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+type: Opaque
+data:
+  rootUser: "UEZZMG01bzhmS3kzd3c5NFF4THc="
+  rootPassword: "UjJGeGlicUxicHpCRzV0VTM4M1B6Q1AxSUVETDBMT1ZsSGxrb212RA=="

--- a/charts/mla-secrets/test/config.yaml.out
+++ b/charts/mla-secrets/test/config.yaml.out
@@ -7,7 +7,7 @@ metadata:
 type: Opaque
 data:
   admin-user: "YWRtaW4="
-  admin-password: "aG5DMGRvQ0FxbGtjbmI0Z21ORm5xeUpzRWFpZDE1ajBRWDhwRDhwUQ=="
+  admin-password: "aHRKOWJOa0k5eFRIVUp6VzUxdG9Mb2toRmFBTjBsVHdMVVNxQW0ySw=="
 ---
 # Source: mla-secrets/templates/minio-secret.yaml
 apiVersion: v1
@@ -16,5 +16,5 @@ metadata:
   name: minio
 type: Opaque
 data:
-  rootUser: "UEZZMG01bzhmS3kzd3c5NFF4THc="
-  rootPassword: "UjJGeGlicUxicHpCRzV0VTM4M1B6Q1AxSUVETDBMT1ZsSGxrb212RA=="
+  rootUser: "YU1ITnFUdE5kVmJqM2V0UGNwQlU="
+  rootPassword: "ekRFSHI2WE1CeVNTSGp1WjlOTWxsbkZUdEtTbHhDSzVEbDRCSURSUQ=="

--- a/charts/mla-secrets/test/default.yaml
+++ b/charts/mla-secrets/test/default.yaml
@@ -1,0 +1,13 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/mla-secrets/test/default.yaml
+++ b/charts/mla-secrets/test/default.yaml
@@ -11,3 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+mlaSecrets:
+  minio:
+    accessKey: "memorableAccessKey"
+    secretKey: "strongPassword"
+
+  grafana:
+    adminPassword: "strongPassword"

--- a/charts/mla-secrets/test/default.yaml.out
+++ b/charts/mla-secrets/test/default.yaml.out
@@ -1,0 +1,20 @@
+---
+# Source: mla-secrets/templates/grafana-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana
+type: Opaque
+data:
+  admin-user: "YWRtaW4="
+  admin-password: "bWpZWlcyQWd5bGhkS1hJZmJoZG0wV1BZNWdmMHFZOXpCeEg0WFoycQ=="
+---
+# Source: mla-secrets/templates/minio-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+type: Opaque
+data:
+  rootUser: "eUJtQkU4S1N5a1h4NnI0WGRMZ2Q="
+  rootPassword: "UjFqTVRZUWdEbVV3dVZBT0ZuS2pyYVJRY2xMT1JiU2lrZDN6WVZzdg=="

--- a/charts/mla-secrets/test/default.yaml.out
+++ b/charts/mla-secrets/test/default.yaml.out
@@ -7,7 +7,7 @@ metadata:
 type: Opaque
 data:
   admin-user: "YWRtaW4="
-  admin-password: "bWpZWlcyQWd5bGhkS1hJZmJoZG0wV1BZNWdmMHFZOXpCeEg0WFoycQ=="
+  admin-password: "c3Ryb25nUGFzc3dvcmQ="
 ---
 # Source: mla-secrets/templates/minio-secret.yaml
 apiVersion: v1
@@ -16,5 +16,5 @@ metadata:
   name: minio
 type: Opaque
 data:
-  rootUser: "eUJtQkU4S1N5a1h4NnI0WGRMZ2Q="
-  rootPassword: "UjFqTVRZUWdEbVV3dVZBT0ZuS2pyYVJRY2xMT1JiU2lrZDN6WVZzdg=="
+  rootUser: "bWVtb3JhYmxlQWNjZXNzS2V5"
+  rootPassword: "c3Ryb25nUGFzc3dvcmQ="

--- a/charts/mla-secrets/test/test.sh
+++ b/charts/mla-secrets/test/test.sh
@@ -1,0 +1,1 @@
+../../../hack/test-chart-rendering.sh

--- a/charts/mla-secrets/values.yaml
+++ b/charts/mla-secrets/values.yaml
@@ -12,57 +12,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-minio:
-  ## Set enabled to false if you want to re-use an existing secret for minio.
-  enabled: true
-  ## Set default accesskey, secretkey
-  ## AccessKey and secretKey is generated when not set
-  accessKey: ""
-  secretKey: ""
-
-  ## Use minio as GCS (Google Cloud Storage) gateway.
-  ## https://docs.minio.io/docs/minio-gateway-for-gcs
-  gcsgateway:
-    enabled: false
-    # credential json file of service account key
-    gcsKeyJson: ""
-
-  s3gateway:
-    enabled: false
-    replicas: 4
-    serviceEndpoint: ""
+mlaSecrets:
+  minio:
+    ## Set enabled to false if you want to re-use an existing secret for minio.
+    enabled: true
+    ## Set default accesskey, secretkey
+    ## AccessKey and secretKey is generated when not set
     accessKey: ""
     secretKey: ""
 
-  ## ETCD settings: https://github.com/minio/minio/blob/master/docs/sts/etcd.md
-  ## Define endpoints to enable this section.
-  etcd:
-    clientCert: ""
-    clientCertKey: ""
+    ## Use minio as GCS (Google Cloud Storage) gateway.
+    ## https://docs.minio.io/docs/minio-gateway-for-gcs
+    gcsgateway:
+      enabled: false
+      # credential json file of service account key
+      gcsKeyJson: ""
 
-grafana:
-  ## Set enabled to false if you want to re-use an existing secret for grafana.
-  enabled: true
-  adminUser: admin
-#  adminPassword: strongpassword
+    s3gateway:
+      enabled: false
+      replicas: 4
+      serviceEndpoint: ""
+      accessKey: ""
+      secretKey: ""
 
-  ## Grafana's LDAP configuration
-  ## Templated by the template in _helpers.tpl
-  ## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
-  ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
-  ## ref: http://docs.grafana.org/installation/ldap/#configuration
-  ldap:
-    enabled: false
-    # `config` is the content of `ldap.toml` that will be stored in the created secret
-    config: ""
-    # config: |-
-    #   verbose_logging = true
+    ## ETCD settings: https://github.com/minio/minio/blob/master/docs/sts/etcd.md
+    ## Define endpoints to enable this section.
+    etcd:
+      clientCert: ""
+      clientCertKey: ""
 
-    #   [[servers]]
-    #   host = "my-ldap-server"
-    #   port = 636
-    #   use_ssl = true
-    #   start_tls = false
-    #   ssl_skip_verify = false
-    #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
+  grafana:
+    ## Set enabled to false if you want to re-use an existing secret for grafana.
+    enabled: true
+    adminUser: admin
+  #  adminPassword: strongpassword
+
+    ## Grafana's LDAP configuration
+    ## Templated by the template in _helpers.tpl
+    ## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
+    ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
+    ## ref: http://docs.grafana.org/installation/ldap/#configuration
+    ldap:
+      enabled: false
+      # `config` is the content of `ldap.toml` that will be stored in the created secret
+      config: ""
+      # config: |-
+      #   verbose_logging = true
+
+      #   [[servers]]
+      #   host = "my-ldap-server"
+      #   port = 636
+      #   use_ssl = true
+      #   start_tls = false
+      #   ssl_skip_verify = false
+      #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"

--- a/config/mla-secrets/values.yaml
+++ b/config/mla-secrets/values.yaml
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-grafana:
-  ## Set enabled to false if you want to re-use an existing secret for grafana.
-  enabled: true
-  adminuser: admin
+mlaSecrets:
+  grafana:
+    ## Set enabled to false if you want to re-use an existing secret for grafana.
+    enabled: true
+    adminuser: admin
 
-minio:
-  ## Set enabled to false if you want to re-use an existing secret for minio.
-  enabled: true
+  minio:
+    ## Set enabled to false if you want to re-use an existing secret for minio.
+    enabled: true


### PR DESCRIPTION
This commit prefixes the last 2 charts so that it's possible to use a single values-file to install any chart.

mla-secrets:
* received `mlaSecrets` prefix

alertmanager-proxy:
* prefixed with `alertmanagerProxy`
* `alertmanagerProxy` is moved to `alertmanagerProxy.proxy`
* `alertmanagerAuthzServer` is moved to `alertmanagerProxy.authz`

fixes #62 