### PR TITLE
Allow further customization of minio-lifecycle-manager chart

### DIFF
--- a/charts/minio-lifecycle-mgr/templates/lifecycle-mgr-cronjob.yaml
+++ b/charts/minio-lifecycle-mgr/templates/lifecycle-mgr-cronjob.yaml
@@ -43,3 +43,15 @@ spec:
               configMap:
                 name: minio-lifecycle-mgr-scripts
                 defaultMode: 0777
+{{- with .Values.lifecycleMgr.nodeSelector }}
+          nodeSelector:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- with .Values.lifecycleMgr.affinity }}
+          affinity:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- with .Values.lifecycleMgr.tolerations }}
+          tolerations:
+{{ toYaml . | indent 12 }}
+{{- end }}

--- a/charts/minio-lifecycle-mgr/test/config.yaml
+++ b/charts/minio-lifecycle-mgr/test/config.yaml
@@ -1,0 +1,1 @@
+../../../config/cortex/values.yaml

--- a/charts/minio-lifecycle-mgr/test/config.yaml.out
+++ b/charts/minio-lifecycle-mgr/test/config.yaml.out
@@ -1,0 +1,70 @@
+---
+# Source: minio-lifecycle-mgr/templates/lifecycle-mgr-configmap.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name:  minio-lifecycle-mgr-scripts
+data:
+  ensure-lifecycle.sh: |
+    mc alias set minio http://minio:9000 $rootUser $rootPassword
+---
+# Source: minio-lifecycle-mgr/templates/lifecycle-mgr-cronjob.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: minio-lifecycle-mgr
+spec:
+  schedule: "0 1 * * *"
+  successfulJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: minio
+              image: minio/mc
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+                - /scripts/ensure-lifecycle.sh
+              envFrom:
+                - secretRef:
+                    name: minio
+              volumeMounts:
+                - mountPath: /scripts
+                  name: scripts
+          volumes:
+            - name: scripts
+              configMap:
+                name: minio-lifecycle-mgr-scripts
+                defaultMode: 0777

--- a/charts/minio-lifecycle-mgr/test/default.yaml
+++ b/charts/minio-lifecycle-mgr/test/default.yaml
@@ -1,0 +1,13 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/minio-lifecycle-mgr/test/default.yaml
+++ b/charts/minio-lifecycle-mgr/test/default.yaml
@@ -11,3 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+lifecycleMgr:
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: 
+    key1: value1
+  tolerations:
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoSchedule"
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - store
+        topologyKey: "kubernetes.io/hostname"

--- a/charts/minio-lifecycle-mgr/test/default.yaml.out
+++ b/charts/minio-lifecycle-mgr/test/default.yaml.out
@@ -1,0 +1,70 @@
+---
+# Source: minio-lifecycle-mgr/templates/lifecycle-mgr-configmap.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name:  minio-lifecycle-mgr-scripts
+data:
+  ensure-lifecycle.sh: |
+    mc alias set minio http://minio:9000 $rootUser $rootPassword
+---
+# Source: minio-lifecycle-mgr/templates/lifecycle-mgr-cronjob.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: minio-lifecycle-mgr
+spec:
+  schedule: "0 1 * * *"
+  successfulJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: minio
+              image: minio/mc
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+                - /scripts/ensure-lifecycle.sh
+              envFrom:
+                - secretRef:
+                    name: minio
+              volumeMounts:
+                - mountPath: /scripts
+                  name: scripts
+          volumes:
+            - name: scripts
+              configMap:
+                name: minio-lifecycle-mgr-scripts
+                defaultMode: 0777

--- a/charts/minio-lifecycle-mgr/test/default.yaml.out
+++ b/charts/minio-lifecycle-mgr/test/default.yaml.out
@@ -68,3 +68,20 @@ spec:
               configMap:
                 name: minio-lifecycle-mgr-scripts
                 defaultMode: 0777
+          nodeSelector:
+            key1: value1
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - store
+                topologyKey: kubernetes.io/hostname
+          tolerations:
+            - effect: NoSchedule
+              key: key1
+              operator: Equal
+              value: value1

--- a/charts/minio-lifecycle-mgr/test/test.sh
+++ b/charts/minio-lifecycle-mgr/test/test.sh
@@ -1,0 +1,1 @@
+../../../hack/test-chart-rendering.sh

--- a/charts/minio-lifecycle-mgr/values.yaml
+++ b/charts/minio-lifecycle-mgr/values.yaml
@@ -21,3 +21,10 @@ lifecycleMgr:
 #      expirationDays: 15
 #    - name: loki
 #      expirationDays: 15
+
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
fixes #123 

Adds configurable affinities, tolerations and nodeselectors to the cronjob