### PR TITLE
add GroupProjectBinding rule for alertmanager autz rbac

### DIFF
--- a/charts/alertmanager-proxy/templates/authzserver-clusterrole.yaml
+++ b/charts/alertmanager-proxy/templates/authzserver-clusterrole.yaml
@@ -23,6 +23,7 @@ rules:
       - clusters
       - users
       - userprojectbindings
+      - groupprojectbindings
     verbs:
       - get
       - list


### PR DESCRIPTION
Adds permissions for GroupProjectBindings to alertmanager authz server.