### PR TITLE
upgrade grafana to version 9.1.5

### DIFF
--- a/charts/grafana/Chart.lock
+++ b/charts/grafana/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.17.5
-digest: sha256:e0e860342e2ab2920ef4ca8c70dfbcefb4ab507ccbb5c61afc8753dc2adf9bf2
-generated: "2022-04-15T15:28:15.1577743+02:00"
+  version: 6.38.5
+digest: sha256:c5cd3b0ef1ef5002f0222b65c3e694374966d40936115892343738084d9f408c
+generated: "2022-09-20T07:41:03.712018292Z"

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 8.2.3
+appVersion: 9.1.5
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png
@@ -8,8 +8,8 @@ name: grafana
 sources:
 - https://github.com/grafana/grafana
 type: application
-version: 6.17.5
+version: 6.38.5
 dependencies:
   - name: grafana
     repository: https://grafana.github.io/helm-charts
-    version: 6.17.5
+    version: 6.38.5

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -18,11 +18,15 @@ grafana:
     create: true
     name:
     nameTest:
+  ## Service account annotations. Can be templated.
   #  annotations:
   #    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
     autoMount: true
 
   replicas: 1
+
+  ## Create a headless service for the deployment
+  headlessService: false
 
   ## Create HorizontalPodAutoscaler object for deployment type
   #
@@ -71,13 +75,15 @@ grafana:
 
   image:
     repository: grafana/grafana
-    #tag: 8.2.3
+    # Overrides the Grafana image tag whose default is the chart appVersion
+    tag: ""
     sha: ""
     pullPolicy: IfNotPresent
 
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Can be templated.
     ##
     # pullSecrets:
     #   - myRegistrKeySecretName
@@ -97,6 +103,11 @@ grafana:
   containerSecurityContext:
     {}
 
+  # Enable creating the grafana configmap
+  createConfigmap: true
+
+  # Extra configmaps to mount in grafana pods
+  # Values are templated.
   extraConfigmapMounts: []
     # - name: certs-configmap
     #   mountPath: /etc/grafana/ssl/
@@ -118,7 +129,7 @@ grafana:
 
   downloadDashboardsImage:
     repository: curlimages/curl
-    tag: 7.73.0
+    tag: 7.85.0
     sha: ""
     pullPolicy: IfNotPresent
 
@@ -126,6 +137,7 @@ grafana:
     env: {}
     envFromSecret: ""
     resources: {}
+    securityContext: {}
 
   ## Pod Annotations
   # podAnnotations: {}
@@ -148,9 +160,12 @@ grafana:
     port: 80
     targetPort: 3000
       # targetPort: 4181 To be used with a proxy extraContainer
+    ## Service annotations. Can be templated.
     annotations: {}
     labels: {}
     portName: service
+    # Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+    appProtocol: ""
 
   serviceMonitor:
     ## If true, a ServiceMonitor CRD is created for a prometheus operator
@@ -234,11 +249,19 @@ grafana:
   ##
   tolerations: []
 
-  ## Affinity for pod assignment
+  ## Affinity for pod assignment (evaluated as template)
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
   affinity: {}
 
+  ## Topology Spread Constraints
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  ##
+  topologySpreadConstraints: []
+
+  ## Additional init containers (evaluated as template)
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  ##
   extraInitContainers: []
 
   ## Enable an Specify container in extraContainers. This is meant to allow adding an authentication proxy to a grafana pod
@@ -281,7 +304,9 @@ grafana:
     finalizers:
       - kubernetes.io/pvc-protection
     # selectorLabels: {}
+    ## Sub-directory of the PV to mount. Can be templated.
     # subPath: ""
+    ## Name of an existing PVC. Can be templated.
     # existingClaim:
 
     ## If persistence is not enabled, this allows to mount the
@@ -327,7 +352,8 @@ grafana:
 
   # Use an existing secret for the admin user.
   admin:
-    existingSecret: grafana
+    ## Name of the secret. Can be templated.
+    existingSecret: "grafana"
     userKey: admin-user
     passwordKey: admin-password
 
@@ -367,8 +393,8 @@ grafana:
 
   env: {}
 
-  ## "valueFrom" environment variable references that will be added to deployment pods
-  ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core
+  ## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+  ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
   ## Renders in container spec as:
   ##   env:
   ##     ...
@@ -376,6 +402,10 @@ grafana:
   ##       valueFrom:
   ##         <value rendered as YAML>
   envValueFrom: {}
+    #  ENV_NAME:
+    #    configMapKeyRef:
+    #      name: configmap-name
+    #      key: value_key
 
   ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
   ## This can be useful for auth tokens, etc. Value is templated.
@@ -387,8 +417,17 @@ grafana:
 
   ## The names of secrets in the same kubernetes namespace which contain values to be added to the environment
   ## Each entry should contain a name key, and can optionally specify whether the secret must be defined with an optional key.
+  ## Name is templated.
   envFromSecrets: []
   ## - name: secret-name
+  ##   optional: true
+
+  ## The names of conifgmaps in the same kubernetes namespace which contain values to be added to the environment
+  ## Each entry should contain a name key, and can optionally specify whether the configmap must be defined with an optional key.
+  ## Name is templated.
+  ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapenvsource-v1-core
+  envFromConfigMaps: []
+  ## - name: configmap-name
   ##   optional: true
 
   # Inject Kubernetes services as environment variables.
@@ -439,6 +478,19 @@ grafana:
     #   mountPath: /mnt/volume1
     #   readOnly: true
     #   hostPath: /usr/shared/
+    # - name: grafana-secrets
+    #   csi: true
+    #   data:
+    #     driver: secrets-store.csi.k8s.io
+    #     readOnly: true
+    #     volumeAttributes:
+    #       secretProviderClass: "grafana-env-spc"
+
+  ## Container Lifecycle Hooks. Execute a specific bash command or make an HTTP request
+  lifecycleHooks: {}
+    # postStart:
+    #   exec:
+    #     command: []
 
   ## Pass the plugins you want installed as a list.
   ##
@@ -466,6 +518,71 @@ grafana:
   #      jsonData:
   #        authType: default
   #        defaultRegion: us-east-1
+
+  ## Configure grafana alerting (can be templated)
+  ## ref: http://docs.grafana.org/administration/provisioning/#alerting
+  ##
+  alerting: {}
+  #  rules.yaml: |
+  #    apiVersion: 1
+  #    groups:
+  #      - orgId: 1
+  #        name: {{ .Chart.Name }}_my_rule_group
+  #        folder: my_first_folder
+  #        interval: 60s
+  #        rules:
+  #          - uid: my_id_1
+  #            title: my_first_rule
+  #            condition: A
+  #            data:
+  #              - refId: A
+  #                datasourceUid: '-100'
+  #                model:
+  #                  conditions:
+  #                    - evaluator:
+  #                        params:
+  #                          - 3
+  #                        type: gt
+  #                      operator:
+  #                        type: and
+  #                      query:
+  #                        params:
+  #                          - A
+  #                      reducer:
+  #                        type: last
+  #                      type: query
+  #                  datasource:
+  #                    type: __expr__
+  #                    uid: '-100'
+  #                  expression: 1==0
+  #                  intervalMs: 1000
+  #                  maxDataPoints: 43200
+  #                  refId: A
+  #                  type: math
+  #            dashboardUid: my_dashboard
+  #            panelId: 123
+  #            noDataState: Alerting
+  #            for: 60s
+  #            annotations:
+  #              some_key: some_value
+  #            labels:
+  #              team: sre_team_1
+  #  contactpoints.yaml: |
+  #    apiVersion: 1
+  #    contactPoints:
+  #      - orgId: 1
+  #        name: cp_1
+  #        receivers:
+  #          - uid: first_uid
+  #            type: pagerduty
+  #            settings:
+  #              integrationKey: XXX
+  #              severity: critical
+  #              class: ping failure
+  #              component: Grafana
+  #              group: app-stack
+  #              summary: |
+  #                {{ `{{ template "default.message" . }}` }}
 
   ## Configure notifiers
   ## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels
@@ -527,6 +644,12 @@ grafana:
     #     url: https://example.com/repository/test-b64.json
     #     token: ''
     #     b64content: true
+    #   local-dashboard-gitlab:
+    #     url: https://example.com/repository/test-gitlab.json
+    #     gitlabToken: ''
+    #   local-dashboard-bitbucket:
+    #     url: https://example.com/repository/test-bitbucket.json
+    #     bearerToken: ''
 
   ## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.
   ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.
@@ -555,6 +678,8 @@ grafana:
       mode: console
     grafana_net:
       url: https://grafana.net
+    server:
+      domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ .Values.ingress.hosts | first }}{{ else }}''{{ end }}"
   ## grafana Authentication can be enabled with the following values on grafana.ini
   # server:
         # The full public facing url you use in browser, used for redirects and emails
@@ -616,7 +741,7 @@ grafana:
   sidecar:
     image:
       repository: quay.io/kiwigrid/k8s-sidecar
-      tag: 1.14.2
+      tag: 1.19.2
       sha: ""
     imagePullPolicy: IfNotPresent
     resources: {}
@@ -626,16 +751,27 @@ grafana:
   #   requests:
   #     cpu: 50m
   #     memory: 50Mi
+    securityContext: {}
     # skipTlsVerify Set to true to skip tls verification for kube api calls
     # skipTlsVerify: true
     enableUniqueFilenames: false
+    readinessProbe: {}
+    livenessProbe: {}
+    # Log level default for all sidecars. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL. Defaults to INFO
+    # logLevel: INFO
     dashboards:
       enabled: false
+      # Additional environment variables for the dashboards sidecar
+      env: {}
+      # Do not reprocess already processed unchanged resources on k8s API reconnect.
+      # ignoreAlreadyProcessed: true
       SCProvider: true
       # label that the configmaps with dashboards are marked with
       label: grafana_dashboard
       # value of label that the configmaps with dashboards are set to
-      labelValue: null
+      labelValue: ""
+      # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+      # logLevel: INFO
       # folder in the pod that should hold the collected dashboards (unless `defaultFolderName` is set)
       folder: /tmp/dashboards
       # The default folder name, it will create a subfolder under the `folder` and put dashboards in there instead
@@ -644,11 +780,25 @@ grafana:
       # Otherwise the namespace in which the sidecar is running will be used.
       # It's also possible to specify ALL to search in all namespaces.
       searchNamespace: null
+      # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+      watchMethod: WATCH
       # search in configmap, secret or both
       resource: both
       # If specified, the sidecar will look for annotation with this name to create folder and put graph here.
       # You can use this parameter together with `provider.foldersFromFilesStructure`to annotate configmaps and create folder structure.
       folderAnnotation: null
+      # Absolute path to shell script to execute after a configmap got reloaded
+      script: null
+      # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+      # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+      # watchServerTimeout: 3600
+      #
+      # watchClientTimeout: is a client-side timeout, configuring your local socket.
+      # If you have a network outage dropping all packets with no RST/FIN,
+      # this is how long your client waits before realizing & dropping the connection.
+      # defaults to 66sec (sic!)
+      # watchClientTimeout: 60
+      #
       # provider configuration that lets grafana manage the dashboards
       provider:
         # name of the provider, should be unique
@@ -665,28 +815,110 @@ grafana:
         allowUiUpdates: false
         # allow Grafana to replicate dashboard structure from filesystem
         foldersFromFilesStructure: false
+      # Additional dashboard sidecar volume mounts
+      extraMounts: []
+      # Sets the size limit of the dashboard sidecar emptyDir volume
+      sizeLimit: {}
     datasources:
       enabled: false
+      # Additional environment variables for the datasourcessidecar
+      env: {}
+      # Do not reprocess already processed unchanged resources on k8s API reconnect.
+      # ignoreAlreadyProcessed: true
       # label that the configmaps with datasources are marked with
       label: grafana_datasource
       # value of label that the configmaps with datasources are set to
-      labelValue: null
+      labelValue: ""
+      # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+      # logLevel: INFO
       # If specified, the sidecar will search for datasource config-maps inside this namespace.
       # Otherwise the namespace in which the sidecar is running will be used.
       # It's also possible to specify ALL to search in all namespaces
       searchNamespace: null
+      # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+      watchMethod: WATCH
       # search in configmap, secret or both
       resource: both
+      # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+      # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+      # watchServerTimeout: 3600
+      #
+      # watchClientTimeout: is a client-side timeout, configuring your local socket.
+      # If you have a network outage dropping all packets with no RST/FIN,
+      # this is how long your client waits before realizing & dropping the connection.
+      # defaults to 66sec (sic!)
+      # watchClientTimeout: 60
+      #
+      # Endpoint to send request to reload datasources
+      reloadURL: "http://localhost:3000/api/admin/provisioning/datasources/reload"
+      # Absolute path to shell script to execute after a datasource got reloaded
+      script: null
+      skipReload: false
+      # Deploy the datasource sidecar as an initContainer in addition to a container.
+      # This is needed if skipReload is true, to load any datasources defined at startup time.
+      initDatasources: false
+      # Sets the size limit of the datasource sidecar emptyDir volume
+      sizeLimit: {}
+    plugins:
+      enabled: false
+      # Additional environment variables for the plugins sidecar
+      env: {}
+      # Do not reprocess already processed unchanged resources on k8s API reconnect.
+      # ignoreAlreadyProcessed: true
+      # label that the configmaps with plugins are marked with
+      label: grafana_plugin
+      # value of label that the configmaps with plugins are set to
+      labelValue: ""
+      # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+      # logLevel: INFO
+      # If specified, the sidecar will search for plugin config-maps inside this namespace.
+      # Otherwise the namespace in which the sidecar is running will be used.
+      # It's also possible to specify ALL to search in all namespaces
+      searchNamespace: null
+      # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+      watchMethod: WATCH
+      # search in configmap, secret or both
+      resource: both
+      # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+      # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+      # watchServerTimeout: 3600
+      #
+      # watchClientTimeout: is a client-side timeout, configuring your local socket.
+      # If you have a network outage dropping all packets with no RST/FIN,
+      # this is how long your client waits before realizing & dropping the connection.
+      # defaults to 66sec (sic!)
+      # watchClientTimeout: 60
+      #
+      # Endpoint to send request to reload plugins
+      reloadURL: "http://localhost:3000/api/admin/provisioning/plugins/reload"
+      # Absolute path to shell script to execute after a plugin got reloaded
+      script: null
+      skipReload: false
+      # Deploy the datasource sidecar as an initContainer in addition to a container.
+      # This is needed if skipReload is true, to load any plugins defined at startup time.
+      initPlugins: false
+      # Sets the size limit of the plugin sidecar emptyDir volume
+      sizeLimit: {}
     notifiers:
       enabled: false
+      # Additional environment variables for the notifierssidecar
+      env: {}
+      # Do not reprocess already processed unchanged resources on k8s API reconnect.
+      # ignoreAlreadyProcessed: true
       # label that the configmaps with notifiers are marked with
       label: grafana_notifier
+      # value of label that the configmaps with notifiers are set to
+      labelValue: ""
+      # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+      # logLevel: INFO
       # If specified, the sidecar will search for notifier config-maps inside this namespace.
       # Otherwise the namespace in which the sidecar is running will be used.
       # It's also possible to specify ALL to search in all namespaces
       searchNamespace: null
       # search in configmap, secret or both
       resource: both
+      # Sets the size limit of the notifier sidecar emptyDir volume
+      sizeLimit: {}
 
   ## Override the deployment namespace
   ##
@@ -715,6 +947,7 @@ grafana:
       HTTP_HOST: "0.0.0.0"
       # RENDERING_ARGS: --no-sandbox,--disable-gpu,--window-size=1280x758
       # RENDERING_MODE: clustered
+      # IGNORE_HTTPS_ERRORS: true
     # image-renderer deployment serviceAccount
     serviceAccountName: ""
     # image-renderer deployment securityContext
@@ -731,6 +964,10 @@ grafana:
       # image-renderer service port used by both service and deployment
       port: 8081
       targetPort: 8081
+      # Adds the appProtocol field to the image-renderer service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+      appProtocol: ""
+    # If https is enabled in Grafana, this needs to be set as 'https' to correctly configure the callback used in Grafana
+    grafanaProtocol: http
     # In case a sub_path is used this needs to be added to the image renderer callback
     grafanaSubPath: ""
     # name of the image-renderer port on the pod
@@ -749,3 +986,86 @@ grafana:
   #   requests:
   #     cpu: 50m
   #     memory: 50Mi
+    ## Node labels for pod assignment
+    ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+    #
+    nodeSelector: {}
+
+    ## Tolerations for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    ##
+    tolerations: []
+
+    ## Affinity for pod assignment (evaluated as template)
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    affinity: {}
+
+  networkPolicy:
+    ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+    ##
+    enabled: false
+    ## @param networkPolicy.allowExternal Don't require client label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## client label will have network access to  grafana port defined.
+    ## When true, grafana will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    ingress: true
+    ## @param networkPolicy.ingress When true enables the creation
+    ## an ingress network policy
+    ##
+    allowExternal: true
+    ## @param networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed
+    ## If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+    ## and that match other criteria, the ones that have the good label, can reach the grafana.
+    ## But sometimes, we want the grafana to be accessible to clients from other namespaces, in this case, we can use this
+    ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+    ##
+    ## Example:
+    ## explicitNamespacesSelector:
+    ##   matchLabels:
+    ##     role: frontend
+    ##   matchExpressions:
+    ##    - {key: role, operator: In, values: [frontend]}
+    ##
+    explicitNamespacesSelector: {}
+    ##
+    ##
+    ##
+    ##
+    ##
+    ##
+    egress:
+      ## @param networkPolicy.egress.enabled When enabled, an egress network policy will be
+      ## created allowing grafana to connect to external data sources from kubernetes cluster.
+      enabled: false
+      ##
+      ## @param networkPolicy.egress.ports Add individual ports to be allowed by the egress
+      ports: []
+      ## Add ports to the egress by specifying - port: <port number>
+      ## E.X.
+      ## ports:
+        ## - port: 80
+        ## - port: 443
+    ##
+    ##
+    ##
+    ##
+    ##
+    ##
+
+  # Enable backward compatibility of kubernetes where version below 1.13 doesn't have the enableServiceLinks option
+  enableKubeBackwardCompatibility: false
+  useStatefulSet: false
+  # Create a dynamic manifests via values:
+  extraObjects: []
+    # - apiVersion: "kubernetes-client.io/v1"
+    #   kind: ExternalSecret
+    #   metadata:
+    #     name: grafana-secrets
+    #   spec:
+    #     backendType: gcpSecretsManager
+    #     data:
+    #       - key: grafana-admin-password
+    #         name: adminPassword


### PR DESCRIPTION
Signed-off-by: Christian Schnidrig <christian.schnidrig@switch.ch>

**What this PR does / why we need it**:

It upgrades Grafana to version 9.1.5 (currently the newest version available)

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

Grafana has added a lot of functionality in monitoring / alerting (https://grafana.com/docs/grafana/latest/alerting/fundamentals/).
This PR does not yet allow for users to use that new functionality. However, the Grafana upgrade is a prerequisite for a second PR in the kubermatic repo (seed-controller-manger) that will configure the datasources and the mla-gateway such that the new functionality in Grafana can actually be used.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

Grafana upgraded to version 9.1.5

```

**Documentation**: 
  - NONE (no documentation needed for this PR)


<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
-->
```documentation
```
