### PR TITLE
fix yq version check

### DIFF
--- a/hack/fetch-chart-dependencies.sh
+++ b/hack/fetch-chart-dependencies.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 if `which yq4`; then
   YQ=yq4
 else
-  yq --version | grep "version 4" >/dev/null || (echo "yq version 3 not supported, exiting..."; exit 1)
+  yq --version | grep "version.*4" >/dev/null || (echo "yq version 3 not supported, exiting..."; exit 1)
   YQ=yq
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
At my mac, the `yq --version` output is not matching the grep pattern.
```
yq --version
yq (https://github.com/mikefarah/yq/) version v4.30.8
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix yq 4 version check
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
