### PR TITLE
Regenerate KKP dashboards from release/v2.21 branch

### DIFF
--- a/dashboards/kkp-kubernetes.yaml
+++ b/dashboards/kkp-kubernetes.yaml
@@ -54,7 +54,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (node_name) (sum by (node_name) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+              "expr": "avg by (node_name) (100 - (irate(node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ node_name }}",
@@ -165,7 +165,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg (sum by (node_name) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+              "expr": "avg (100 - (irate(node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "refId": "A"
@@ -2273,7 +2273,7 @@ data:
               "refId": "B"
             },
             {
-              "expr": "sum (kube_pod_container_resource_limits_memory_bytes{job=\"kube-state-metrics\", namespace=\"$namespace\", pod=\"$pod\"})",
+              "expr": "sum (kube_pod_container_resource_limits{resource=\"memory\", job=\"kube-state-metrics\", namespace=\"$namespace\", pod=\"$pod\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Limit",
@@ -2376,7 +2376,7 @@ data:
               "refId": "B"
             },
             {
-              "expr": "sum by(container) (kube_pod_container_resource_limits_memory_bytes{job=\"kube-state-metrics\", namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\"})",
+              "expr": "sum by(container) (kube_pod_container_resource_limits{resource=\"memory\", job=\"kube-state-metrics\", namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Limit: {{ container }}",

--- a/hack/generate-kkp-dashboards.sh
+++ b/hack/generate-kkp-dashboards.sh
@@ -2,7 +2,7 @@
 
 KKP_REPO_DIR="${KKP_REPO_DIR:-}"
 KKP_REPO_URL="${KKP_REPO_URL:-https://github.com/kubermatic/kubermatic.git}"
-KKP_REPO_TAG="${KKP_REPO_TAG:-weekly-2021-33}"
+KKP_REPO_TAG="${KKP_REPO_TAG:-release/v2.21}"
 
 TMP_REPO_DIR="${TMP_REPO_DIR:-/tmp/kubermatic-sources}"
 TMP_DASHBOARD_DIR="${TMP_DASHBOARD_DIR:-/tmp/kkp-dashboards}"


### PR DESCRIPTION
**What this PR does / why we need it**:
I ran the `hack/generate-kkp-dashboards.sh` script to update from the latest dashboards in `release/v2.21`. This was the result.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update to latest KKP dashboards (fixes CPU utilisation graphs and use `kube_pod_container_resource_limits` metric instead of `kube_pod_container_resource_limits_memory_bytes`)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
