### PR TITLE
Added a filter which allows blackbox exporter to query without authz filter for health endpoint

### DIFF
--- a/charts/alertmanager-proxy/templates/proxy-configmap.yaml
+++ b/charts/alertmanager-proxy/templates/proxy-configmap.yaml
@@ -52,8 +52,27 @@ data:
                 virtual_hosts:
                 - name: local_service
                   domains: ["*"]
+                  # Added this to allow per-route filter disabling for healthcheck endpoint
+                  # Ref: https://www.envoyproxy.io/docs/envoy/v1.18.4/configuration/http/http_filters/ext_authz_filter#per-route-configuration
+                  typed_per_filter_config:
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      check_settings:
+                        context_extensions:
+                          virtual_host: local_service
                   routes:
-
+                  # Added healthcheck route with Authz filter disabled.
+                  # Ref: https://www.envoyproxy.io/docs/envoy/v1.18.4/configuration/http/http_filters/ext_authz_filter#per-route-configuration
+                  - match:
+                      safe_regex:
+                        google_re2: {}
+                        regex: '/ready$'
+                    route:
+                      cluster: service_backend
+                    typed_per_filter_config:
+                      envoy.filters.http.ext_authz:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                        disabled: true
                   # redirect if the path contains only cluster ID without slash (append slash at the end)
                   - match:
                       safe_regex:


### PR DESCRIPTION
**What this PR does / why we need it**:
We observed that when blackbox-exporter was accessing alertmanager health URL it was getting redirected to authentication request.

So added a special filter which allows certain urls (currently only `/ready`) to be passed through without authentication.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind chore

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
Need cherry pick to 0.2 branch

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
  - NONE (no documentation needed for this PR)
```
